### PR TITLE
Add domain-discovery and tree-generator meta-skills (v2.1)

### DIFF
--- a/skills/domain-discovery/SKILL.md
+++ b/skills/domain-discovery/SKILL.md
@@ -180,9 +180,10 @@ different skills but need the same advice. When a failure mode spans
 domains, list all relevant domain slugs in its `domains` field. The
 skill-tree-generator will write it into every corresponding SKILL file.
 
-Do not force failure modes into a single domain for tidiness. If the
-advice is needed by someone working in domain A and also by someone
-working in domain B, it belongs in both.
+List a cross-domain failure mode once, under its primary domain. Set
+the `domains` field to all domain slugs it applies to. Do not duplicate
+the entry in the YAML — the skill-tree-generator handles duplication
+into multiple SKILL files at generation time.
 
 ### 2f — Identify cross-domain tensions
 
@@ -225,7 +226,7 @@ for import patterns. For each frequently co-used library, log:
 - Whether it's a required or optional integration
 - Any example code showing the integration pattern
 
-These become targeted composition questions in Phase 3f.
+These become targeted composition questions in Phase 3e.
 
 ### 2i — Produce the draft domain map
 
@@ -432,26 +433,63 @@ gaps:
 
 ### 2. skill_spec.md
 
-A human-readable companion that includes:
+A human-readable companion document. Follow this structure:
 
-- Library overview (2–3 sentences, no marketing)
-- Domain table with coverage matrix
-- Full failure mode inventory grouped by domain, distinguishing
-  doc-sourced vs maintainer-sourced failure modes. Flag cross-domain
-  failure modes and list which SKILL files each should appear in.
-- Tensions inventory with the domains in conflict and agent implications
-- Remaining gaps (if any) needing further input
-- Recommended skill file structure: which domains become tier 1 stubs,
-  which become tier 2 sub-skills, which need references/ directories
-- Composition opportunities: which other libraries this one interacts
-  with and what composition skills are needed
+```markdown
+# [Library Name] — Skill Spec
 
-Format the domain table as:
+[2–3 sentences: what this library is, what problem it solves. Factual,
+not promotional.]
 
-```
+## Domain Coverage
+
 | Domain | Skill name | What it covers | Failure modes | Tier |
 |--------|------------|----------------|---------------|------|
 | [name] | [lib]/[slug] | [exhaustive list] | [count] | [1|2] |
+
+## Failure Mode Inventory
+
+### [Domain name] ([count] failure modes)
+
+| # | Mistake | Priority | Source | Cross-domain? |
+|---|---------|----------|--------|---------------|
+| 1 | [phrase] | CRITICAL | [doc/source/interview] | [other domain slugs or —] |
+
+[Repeat table for each domain.]
+
+## Tensions
+
+| Tension | Domains | Agent implication |
+|---------|---------|-------------------|
+| [short phrase] | [slug-a] ↔ [slug-b] | [what agents get wrong] |
+
+## Subsystems & Reference Candidates
+
+| Domain | Subsystems | Reference candidates |
+|--------|------------|---------------------|
+| [slug] | [adapter1, adapter2, ...] or — | [topic needing depth] or — |
+
+## Remaining Gaps
+
+| Domain | Question | Status |
+|--------|----------|--------|
+| [slug] | [what still needs input] | open |
+
+[Omit this section if all gaps were resolved in the interview.]
+
+## Recommended Skill File Structure
+
+- **Core skills:** [list which domains become core sub-skills]
+- **Framework skills:** [list per-framework skills needed]
+- **Composition skills:** [list integration seams needing composition skills]
+- **Reference files:** [list domains needing references/ based on subsystems
+  or dense API surfaces]
+
+## Composition Opportunities
+
+| Library | Integration points | Composition skill needed? |
+|---------|-------------------|--------------------------|
+| [name] | [what interacts] | [yes/no — if yes, skill name] |
 ```
 
 ---

--- a/skills/tree-generator/SKILL.md
+++ b/skills/tree-generator/SKILL.md
@@ -50,7 +50,9 @@ You need one of:
 - Raw library documentation and source code (run a compressed domain
   discovery first)
 
-If starting from raw docs without a domain map:
+If starting from raw docs without a domain map, run a compressed
+discovery. This produces lower-fidelity output than the full
+skill-domain-discovery skill — prefer running that when time permits.
 
 1. Build a concept inventory (every export, config key, constraint, warning)
 2. Group into 4–7 capability domains using work-oriented names
@@ -237,7 +239,8 @@ Minimum working example for this domain.
 
 **3. Common Mistakes**
 
-Minimum 3 entries. Complex domains target 5–6.
+Each `failure_mode` entry from the domain map becomes a Common Mistake
+entry in the SKILL file. Minimum 3 entries. Complex domains target 5–6.
 
 **Cross-domain failure modes:** The domain map may contain failure modes
 with a `domains` list naming multiple domain slugs. Write these into
@@ -271,10 +274,8 @@ Priority levels:
 - **HIGH** — Incorrect behavior under common conditions.
 - **MEDIUM** — Incorrect under specific conditions or edge cases.
 
-Every mistake must be:
-- **Plausible** — An agent would generate this because it looks correct
-- **Silent** — No immediate crash; fails at runtime or conditionally
-- **Grounded** — Traceable to a specific doc page, source, or issue
+Every mistake must be plausible (an agent would generate it), silent
+(no immediate crash), and grounded (traceable to doc or source).
 
 **Failure mode status from domain map:** The domain map may include a
 `status` field on failure modes. Handle as follows:
@@ -402,6 +403,10 @@ toward the related skill where the other side of the tension lives.
 
 ### Step 6 — Write composition skills (if applicable)
 
+Use the `compositions` entries from `domain_map.yaml` (populated during
+skill-domain-discovery Phase 2h) to identify which composition skills
+to produce.
+
 Composition skills cover how two or more libraries work together. These
 are framework-specific by default (the integration patterns depend on
 framework hooks and providers).
@@ -483,7 +488,7 @@ Run every check before outputting. Fix any failures before proceeding.
 | Framework skills don't repeat core content | Only framework-specific |
 | Composition skills don't repeat individual skills | Only the seam |
 | `name` matches directory path | `router-core/search-params` → `router-core/search-params/SKILL.md` |
-| metadata.sources filled | At least one repo:path per sub-skill |
+| `sources` filled in sub-skills | At least one repo:path per sub-skill |
 | Cross-domain failures in all relevant skills | Failure modes with multiple `domains` appear in each listed skill |
 | Tensions noted in affected skills | Each tension has notes in all involved domain skills |
 | Framework domains decomposed per-package | No single skill covering multiple framework adapters |
@@ -558,16 +563,7 @@ current_skills:
    registry
 4. Bump `library_version`
 
-### Step 3 — Update package_map.yaml (only if needed)
-
-The `package_map.yaml` only needs updating when:
-- A new package is added to the library
-- A new framework adapter is published
-- A skill is renamed or removed
-
-For content updates within existing skills, `package_map.yaml` does not change.
-
-### Step 4 — Produce a changelog entry
+### Step 3 — Produce a changelog entry
 
 ```markdown
 ## [date]
@@ -592,7 +588,7 @@ For content updates within existing skills, `package_map.yaml` does not change.
 |-------|------|
 | Under 500 lines per SKILL.md | Move excess to references/; also create references for content depth |
 | Real imports in every code block | Exact package, correct adapter |
-| No concept explanations | No TypeScript/React/framework tutorials |
+| No external concept explanations | No "TypeScript is...", no "React hooks are..." — library-specific concepts are fine |
 | No marketing prose | First body line is heading, code, or dependency note |
 | Complete code blocks | Every block works without modification |
 | Common Mistakes are silent | Not obvious compile errors |
@@ -643,5 +639,4 @@ When updating:
 
 1. staleness_report.yaml
 2. Updated SKILL.md files (core then framework)
-3. Updated package_map.yaml (only if structure changed)
-4. CHANGELOG.md entry
+3. CHANGELOG.md entry


### PR DESCRIPTION
## Summary

- Adds `skills/domain-discovery/SKILL.md` (v2.1) — interviews library maintainers to produce a structured domain map (`domain_map.yaml` + `skill_spec.md`)
- Adds `skills/tree-generator/SKILL.md` (v2.1) — generates SKILL.md files from a domain map

Both skills incorporate feedback from testing against TanStack DB (discussions #2 and #3).

### Key changes from v2.0 feedback

**domain-discovery:**
- Cross-domain failure modes with `domains` list — semi-lattice coverage so the same advice appears in every relevant SKILL file
- Tensions section for explicit cross-domain design conflicts
- AI-agent-specific failure mode questions (Phase 3c) — produced the most critical findings in testing
- Subsystem and reference candidate flagging so the tree-generator knows where depth is needed
- Composition discovery from `package.json` peer deps before interview
- Failure mode `status` field (`active` / `fixed-but-legacy-risk` / `removed`)

**tree-generator:**
- Source repository layout for npm distribution in monorepos + `package.json` `files` array guidance
- Framework-integration domain decomposition per adapter package
- Writes cross-domain failure modes into all relevant SKILL files
- Tension notes with cross-references between involved domain skills
- Content-based reference file heuristics (adapter-heavy domains, dense API surfaces, schema validation) — not just 500-line overflow

## Test plan

- [x] Tested domain-discovery v2.0 against TanStack DB — review in discussion #2
- [x] Tested tree-generator v2.0 against TanStack DB — review in discussion #3
- [x] v2.1 changes address all gaps identified in both reviews
- [ ] Run domain-discovery v2.1 against another library to validate new fields
- [ ] Run tree-generator v2.1 with subsystems/reference_candidates input

🤖 Generated with [Claude Code](https://claude.com/claude-code)