### PR TITLE
fix: rename remaining playbook references to intent

### DIFF
--- a/.github/workflows/skill-staleness-check.yml
+++ b/.github/workflows/skill-staleness-check.yml
@@ -1,7 +1,7 @@
 name: Skill Staleness Check
 
 # Triggered by repository_dispatch from upstream TanStack package repos.
-# Each package repo has a notify-playbook.yml workflow that fires this
+# Each package repo has a notify-intent.yml workflow that fires this
 # event on merge to main with the list of changed files.
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ id: contributing
 
 ## Questions
 
-If you have questions about implementation details, help or support, then please use our dedicated community forum at [Github Discussions](https://github.com/tanstack/playbooks/discussions) **PLEASE NOTE:** If you choose to instead open an issue for your question, your issue will be immediately closed and redirected to the forum.
+If you have questions about implementation details, help or support, then please use our dedicated community forum at [Github Discussions](https://github.com/tanstack/intent/discussions) **PLEASE NOTE:** If you choose to instead open an issue for your question, your issue will be immediately closed and redirected to the forum.
 
 ## Reporting Issues
 
-If you have found what you think is a bug, please [file an issue](https://github.com/tanstack/playbooks/issues/new). **PLEASE NOTE:** Issues that are identified as implementation questions or non-issues will be immediately closed and redirected to [Github Discussions](https://github.com/tanstack/playbooks/discussions)
+If you have found what you think is a bug, please [file an issue](https://github.com/tanstack/intent/issues/new). **PLEASE NOTE:** Issues that are identified as implementation questions or non-issues will be immediately closed and redirected to [Github Discussions](https://github.com/tanstack/intent/discussions)
 
 ## Suggesting new features
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# @tanstack/playbooks
+# @tanstack/intent
 
 Ship compositional knowledge for AI coding agents alongside your npm packages.
 
-Playbooks are npm packages of skills — encoding how tools work together, what patterns apply for which goals, and what to avoid. Skills travel with the tool via `npm update`, not the model's training cutoff.
+Intents are npm packages of skills — encoding how tools work together, what patterns apply for which goals, and what to avoid. Skills travel with the tool via `npm update`, not the model's training cutoff.
 
-`@tanstack/playbooks` is the toolkit for generating, discovering, and maintaining skills for your library.
+`@tanstack/intent` is the toolkit for generating, discovering, and maintaining skills for your library.
 
 ## Install
 
 ```bash
-pnpm add -D @tanstack/playbooks
+pnpm add -D @tanstack/intent
 ```
 
 ## Quick Start
 
 ### For library consumers
 
-Set up playbook discovery in your project's agent config files (CLAUDE.md, .cursorrules, etc.):
+Set up intent discovery in your project's agent config files (CLAUDE.md, .cursorrules, etc.):
 
 ```bash
-npx playbook init
+npx intent init
 ```
 
 List available skills from installed packages:
 
 ```bash
-npx playbook list
+npx intent list
 ```
 
 ### For library maintainers
@@ -33,33 +33,33 @@ npx playbook list
 Generate skills for your library using the guided scaffold workflow:
 
 ```bash
-npx playbook scaffold
+npx intent scaffold
 ```
 
 Validate your skill files:
 
 ```bash
-npx playbook validate
+npx intent validate
 ```
 
 Copy CI and Oz workflow templates into your repo:
 
 ```bash
-npx playbook setup
+npx intent setup
 ```
 
 ## CLI Commands
 
-| Command                   | Description                                       |
-| ------------------------- | ------------------------------------------------- |
-| `playbook init`           | Inject playbook discovery into agent config files |
-| `playbook list [--json]`  | Discover playbook-enabled packages                |
-| `playbook meta`           | List meta-skills for library maintainers          |
-| `playbook scaffold`       | Print the guided skill generation prompt          |
-| `playbook validate [dir]` | Validate SKILL.md files                           |
-| `playbook setup`          | Copy CI/Oz workflow templates                     |
-| `playbook stale [--json]` | Check skills for version drift                    |
-| `playbook feedback`       | Submit skill feedback                             |
+| Command                 | Description                                     |
+| ----------------------- | ----------------------------------------------- |
+| `intent init`           | Inject intent discovery into agent config files |
+| `intent list [--json]`  | Discover intent-enabled packages                |
+| `intent meta`           | List meta-skills for library maintainers        |
+| `intent scaffold`       | Print the guided skill generation prompt        |
+| `intent validate [dir]` | Validate SKILL.md files                         |
+| `intent setup`          | Copy CI/Oz workflow templates                   |
+| `intent stale [--json]` | Check skills for version drift                  |
+| `intent feedback`       | Submit skill feedback                           |
 
 ## License
 

--- a/packages/intent/meta/domain-discovery/SKILL.md
+++ b/packages/intent/meta/domain-discovery/SKILL.md
@@ -64,7 +64,7 @@ Log (but do not group yet):
 - What the library does in one sentence
 - The core abstractions a developer interacts with
 - Which frameworks it supports
-- Any existing skill files, agent configs, or playbooks
+- Any existing skill files, agent configs, or intents
 - Whether the library is a monorepo and which packages matter
 
 ---

--- a/packages/intent/src/feedback.ts
+++ b/packages/intent/src/feedback.ts
@@ -339,7 +339,7 @@ export function submitMetaFeedback(
 ): SubmitResult {
   const md = metaToMarkdown(payload)
 
-  // Always route to TanStack/playbooks
+  // Always route to TanStack/intent
   if (opts.ghAvailable) {
     try {
       const title = `Meta-Skill Feedback: ${payload.metaSkill} (${payload.userRating})`


### PR DESCRIPTION
## Summary
- Rename all remaining `playbook` references to `intent` across docs, comments, and CI workflows
- Updates README.md (`@tanstack/playbooks` → `@tanstack/intent`, all CLI commands)
- Updates CONTRIBUTING.md GitHub URLs, feedback.ts comment, domain-discovery SKILL.md, and staleness CI workflow

## Test plan
- [x] `grep -ri playbook` returns zero matches across the entire codebase
- [ ] Verify CI workflow reference (`notify-intent.yml`) matches upstream repo workflow name

🤖 Generated with [Claude Code](https://claude.com/claude-code)