### PR TITLE
Improve `intent list` output with table layout and skill hierarchy

### DIFF
--- a/packages/intent/src/cli.ts
+++ b/packages/intent/src/cli.ts
@@ -28,12 +28,9 @@ function padColumn(text: string, width: number): string {
   return text.length >= width ? text + '  ' : text.padEnd(width)
 }
 
-function printTable(
-  headers: string[],
-  rows: string[][],
-): void {
-  const widths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)) + 2,
+function printTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map(
+    (h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)) + 2,
   )
 
   const headerLine = headers.map((h, i) => padColumn(h, widths[i]!)).join('')
@@ -103,9 +100,7 @@ function printSkillLine(
   console.log(`${nameStr}${padding}${typeCol}${skill.description}`)
 }
 
-function computeSkillNameWidth(
-  allPackageSkills: SkillDisplay[][],
-): number {
+function computeSkillNameWidth(allPackageSkills: SkillDisplay[][]): number {
   let max = 0
   for (const skills of allPackageSkills) {
     for (const s of skills) {
@@ -143,7 +138,10 @@ async function cmdList(args: string[]): Promise<void> {
     return
   }
 
-  const totalSkills = result.packages.reduce((sum, p) => sum + p.skills.length, 0)
+  const totalSkills = result.packages.reduce(
+    (sum, p) => sum + p.skills.length,
+    0,
+  )
   console.log(
     `\n${result.packages.length} intent-enabled packages, ${totalSkills} skills (${result.packageManager})\n`,
   )


### PR DESCRIPTION
## Summary
- Replace flat skill listing with a two-section layout: a **summary table** (package/version/skill-count/requires) up top, then a **skill tree** below showing parent→child hierarchy via indentation
- Type tags (`[core]`, `[framework]`) conditionally shown only when skills define them
- Column widths computed globally across all packages for consistent alignment

### Before
```
Intent-enabled packages (3 found):

@tanstack/db v0.5.2
  db-core                           Core database concepts and collection setup
  db-core/live-queries              Reactive live queries with automatic re-evaluation
  db-core/optimistic-updates        Optimistic mutation patterns with rollback
```

### After
```
3 intent-enabled packages, 11 skills (pnpm)

PACKAGE             VERSION  SKILLS  REQUIRES
───────────────────────────────────────────────────
@tanstack/db        0.5.2    4       –
@tanstack/react-db  0.5.2    2       @tanstack/db
@tanstack/router    1.120.2  5       –

Skills:

  @tanstack/db
    db-core               [core]        Core database concepts and collection setup
      live-queries        [core]        Reactive live queries with automatic re-evaluation
      optimistic-updates  [core]        Optimistic mutation patterns with rollback
      sync                [core]        Sync engine configuration and conflict resolution
```

## Test plan
- [x] All 127 existing tests pass
- [x] Build succeeds
- [ ] Manually verify with an actual intent-enabled project

🤖 Generated with [Claude Code](https://claude.com/claude-code)