### PR TITLE
Port table layout and skill hierarchy to intent-library list

### DIFF
--- a/packages/intent/src/intent-library.ts
+++ b/packages/intent/src/intent-library.ts
@@ -2,6 +2,98 @@
 
 import type { LibraryScanResult } from './library-scanner.js'
 import { scanLibrary } from './library-scanner.js'
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+function padColumn(text: string, width: number): string {
+  return text.length >= width ? text + '  ' : text.padEnd(width)
+}
+
+function printTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map(
+    (h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)) + 2,
+  )
+
+  const headerLine = headers.map((h, i) => padColumn(h, widths[i]!)).join('')
+  const separator = widths.map((w) => '─'.repeat(w)).join('')
+
+  console.log(headerLine)
+  console.log(separator)
+  for (const row of rows) {
+    console.log(row.map((cell, i) => padColumn(cell, widths[i]!)).join(''))
+  }
+}
+
+interface SkillDisplay {
+  name: string
+  description: string
+  type?: string
+}
+
+function printSkillTree(
+  skills: SkillDisplay[],
+  opts: { nameWidth: number; showTypes: boolean },
+): void {
+  const roots: string[] = []
+  const children = new Map<string, SkillDisplay[]>()
+
+  for (const skill of skills) {
+    const slashIdx = skill.name.indexOf('/')
+    if (slashIdx === -1) {
+      roots.push(skill.name)
+    } else {
+      const parent = skill.name.slice(0, slashIdx)
+      if (!children.has(parent)) children.set(parent, [])
+      children.get(parent)!.push(skill)
+    }
+  }
+
+  if (roots.length === 0) {
+    for (const skill of skills) {
+      if (!roots.includes(skill.name)) roots.push(skill.name)
+    }
+  }
+
+  for (const rootName of roots) {
+    const rootSkill = skills.find((s) => s.name === rootName)
+    if (!rootSkill) continue
+
+    printSkillLine(rootName, rootSkill, 4, opts)
+
+    for (const sub of children.get(rootName) ?? []) {
+      const childName = sub.name.slice(sub.name.indexOf('/') + 1)
+      printSkillLine(childName, sub, 6, opts)
+    }
+  }
+}
+
+function printSkillLine(
+  displayName: string,
+  skill: SkillDisplay,
+  indent: number,
+  opts: { nameWidth: number; showTypes: boolean },
+): void {
+  const nameStr = ' '.repeat(indent) + displayName
+  const padding = ' '.repeat(Math.max(2, opts.nameWidth - nameStr.length))
+  const typeCol = opts.showTypes
+    ? (skill.type ? `[${skill.type}]` : '').padEnd(14)
+    : ''
+  console.log(`${nameStr}${padding}${typeCol}${skill.description}`)
+}
+
+function computeSkillNameWidth(allPackageSkills: SkillDisplay[][]): number {
+  let max = 0
+  for (const skills of allPackageSkills) {
+    for (const s of skills) {
+      const slashIdx = s.name.indexOf('/')
+      const displayName = slashIdx === -1 ? s.name : s.name.slice(slashIdx + 1)
+      const indent = slashIdx === -1 ? 4 : 6
+      max = Math.max(max, indent + displayName.length)
+    }
+  }
+  return max + 2
+}
 
 // ---------------------------------------------------------------------------
 // Commands
@@ -25,23 +117,36 @@ async function cmdList(): Promise<void> {
     return
   }
 
+  const totalSkills = result.packages.reduce(
+    (sum, p) => sum + p.skills.length,
+    0,
+  )
+  console.log(
+    `\n${result.packages.length} intent-enabled packages, ${totalSkills} skills\n`,
+  )
+
+  // Summary table
+  const rows = result.packages.map((pkg) => [
+    pkg.name,
+    pkg.version,
+    String(pkg.skills.length),
+  ])
+  printTable(['PACKAGE', 'VERSION', 'SKILLS'], rows)
+
+  // Skills detail
+  const allSkills = result.packages.map((p) => p.skills)
+  const nameWidth = computeSkillNameWidth(allSkills)
+  const showTypes = result.packages.some((p) => p.skills.some((s) => s.type))
+
+  console.log(`\nSkills:\n`)
   for (const pkg of result.packages) {
-    const header = pkg.description
-      ? `${pkg.name} v${pkg.version} — ${pkg.description}`
-      : `${pkg.name} v${pkg.version}`
-    console.log(header)
-
-    for (const skill of pkg.skills) {
-      const name = skill.name.padEnd(28)
-      const desc = (skill.description || '').padEnd(52)
-      console.log(`  ${name}${desc}${skill.path}`)
-    }
-
+    console.log(`  ${pkg.name}`)
+    printSkillTree(pkg.skills, { nameWidth, showTypes })
     console.log()
   }
 
   if (result.warnings.length > 0) {
-    console.log('Warnings:')
+    console.log(`Warnings:`)
     for (const w of result.warnings) console.log(`  ⚠ ${w}`)
   }
 }


### PR DESCRIPTION
## Summary
- Port the table + skill tree display from `intent list` (#15) to the `intent-library` CLI
- Replace flat `name  description  path` listing with summary table (PACKAGE/VERSION/SKILLS) + hierarchical skill tree
- Both CLIs now share a consistent output format

### Before
```
@tanstack/db v0.5.2 — Reactive data layer for TanStack
  db-core                           Core database concepts and collection setup                  /path/to/skills/db-core/SKILL.md
  db-core/live-queries              Reactive live queries with automatic re-evaluation            /path/to/skills/db-core/live-queries/SKILL.md
  db-core/optimistic-updates        Optimistic mutation patterns with rollback                    /path/to/skills/db-core/optimistic-updates/SKILL.md
```

### After
```
3 intent-enabled packages, 11 skills

PACKAGE             VERSION  SKILLS
──────────────────────────────────────
@tanstack/db        0.5.2    4
@tanstack/react-db  0.5.2    2
@tanstack/router    1.120.2  5

Skills:

  @tanstack/db
    db-core               [core]        Core database concepts and collection setup
      live-queries        [core]        Reactive live queries with automatic re-evaluation
      optimistic-updates  [core]        Optimistic mutation patterns with rollback
      sync                [core]        Sync engine configuration and conflict resolution
```

## Test plan
- [x] All 127 existing tests pass
- [x] Build succeeds
- [ ] Manually verify with an actual intent-library-enabled project

🤖 Generated with [Claude Code](https://claude.com/claude-code)