### PR TITLE
feat: add tanstack-intent keyword to package.json during setup

### DIFF
--- a/.changeset/add-keywords-to-package-json.md
+++ b/.changeset/add-keywords-to-package-json.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Add `tanstack-intent` keyword to package.json during setup

--- a/packages/intent/src/setup.ts
+++ b/packages/intent/src/setup.ts
@@ -239,6 +239,21 @@ export function runEditPackageJson(root: string): EditPackageJsonResult {
   const indentMatch = raw.match(/^(\s+)"/m)
   const indentSize = indentMatch?.[1] ? indentMatch[1].length : 2
 
+  // --- keywords array ---
+  if (!Array.isArray(pkg.keywords)) {
+    pkg.keywords = []
+  }
+  const keywords = pkg.keywords as Array<string>
+  const requiredKeywords = ['tanstack-intent']
+  for (const kw of requiredKeywords) {
+    if (keywords.includes(kw)) {
+      result.alreadyPresent.push(`keywords: "${kw}"`)
+    } else {
+      keywords.push(kw)
+      result.added.push(`keywords: "${kw}"`)
+    }
+  }
+
   // --- files array ---
   if (!Array.isArray(pkg.files)) {
     pkg.files = []


### PR DESCRIPTION
## Summary

- Adds a `tanstack-intent` keyword to the `keywords` array in `package.json` during `intent setup`, making it easier to discover Intent-managed packages via npm search.