### PR TITLE
fix(intent): make workspace package resolution glob-aware and reusable

### DIFF
--- a/.changeset/busy-peas-fail.md
+++ b/.changeset/busy-peas-fail.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Fix workspace package discovery for nested glob patterns, including support for `*` and `**`. Workspace patterns and resolved package roots are now normalized, deduped, and sorted, and the shared resolver has been extracted for reuse by internal workspace scanning.

--- a/packages/intent/src/cli-support.ts
+++ b/packages/intent/src/cli-support.ts
@@ -60,7 +60,7 @@ export async function resolveStaleTargets(
   }
 
   const { findPackagesWithSkills, findWorkspaceRoot } =
-    await import('./setup.js')
+    await import('./workspace-patterns.js')
   const workspaceRoot = findWorkspaceRoot(resolvedRoot)
   if (workspaceRoot) {
     const packageDirs = findPackagesWithSkills(workspaceRoot)

--- a/packages/intent/src/scanner.ts
+++ b/packages/intent/src/scanner.ts
@@ -11,7 +11,7 @@ import {
   findWorkspaceRoot,
   readWorkspacePatterns,
   resolveWorkspacePackages,
-} from './setup.js'
+} from './workspace-patterns.js'
 import type {
   InstalledVariant,
   IntentConfig,

--- a/packages/intent/src/setup.ts
+++ b/packages/intent/src/setup.ts
@@ -6,8 +6,18 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { basename, join, relative } from 'node:path'
-import { parse as parseYaml } from 'yaml'
-import { findSkillFiles } from './utils.js'
+import {
+  findPackagesWithSkills,
+  findWorkspaceRoot,
+  readWorkspacePatterns,
+} from './workspace-patterns.js'
+
+export {
+  findPackagesWithSkills,
+  findWorkspaceRoot,
+  readWorkspacePatterns,
+  resolveWorkspacePackages,
+} from './workspace-patterns.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -349,148 +359,6 @@ export function runEditPackageJson(root: string): EditPackageJsonResult {
   for (const a of result.alreadyPresent) console.log(`  Already present: ${a}`)
 
   return result
-}
-
-// ---------------------------------------------------------------------------
-// Monorepo workspace resolution
-// ---------------------------------------------------------------------------
-
-export function readWorkspacePatterns(root: string): Array<string> | null {
-  // pnpm-workspace.yaml
-  const pnpmWs = join(root, 'pnpm-workspace.yaml')
-  if (existsSync(pnpmWs)) {
-    try {
-      const config = parseYaml(readFileSync(pnpmWs, 'utf8')) as Record<
-        string,
-        unknown
-      >
-      if (Array.isArray(config.packages)) {
-        return config.packages as Array<string>
-      }
-    } catch (err: unknown) {
-      console.error(
-        `Warning: failed to parse ${pnpmWs}: ${err instanceof Error ? err.message : err}`,
-      )
-    }
-  }
-
-  // package.json workspaces
-  const pkgPath = join(root, 'package.json')
-  if (existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
-      if (Array.isArray(pkg.workspaces)) {
-        return pkg.workspaces
-      }
-      if (Array.isArray(pkg.workspaces?.packages)) {
-        return pkg.workspaces.packages
-      }
-    } catch (err: unknown) {
-      console.error(
-        `Warning: failed to parse ${pkgPath}: ${err instanceof Error ? err.message : err}`,
-      )
-    }
-  }
-
-  return null
-}
-
-/**
- * Resolve workspace glob patterns to actual package directories.
- * Handles simple patterns like "packages/*" and "packages/**".
- * Each resolved directory must contain a package.json.
- */
-export function resolveWorkspacePackages(
-  root: string,
-  patterns: Array<string>,
-): Array<string> {
-  const dirs: Array<string> = []
-
-  for (const pattern of patterns) {
-    // Strip trailing /* or /**/* for directory resolution
-    const base = pattern.replace(/\/\*\*?(\/\*)?$/, '')
-    const baseDir = join(root, base)
-    if (!existsSync(baseDir)) continue
-
-    if (pattern.includes('**')) {
-      // Recursive: walk all subdirectories
-      collectPackageDirs(baseDir, dirs)
-    } else if (pattern.endsWith('/*')) {
-      // Single level: direct children
-      let entries: Array<import('node:fs').Dirent>
-      try {
-        entries = readdirSync(baseDir, { withFileTypes: true })
-      } catch {
-        continue
-      }
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue
-        const dir = join(baseDir, entry.name)
-        if (existsSync(join(dir, 'package.json'))) {
-          dirs.push(dir)
-        }
-      }
-    } else {
-      // Exact path
-      const dir = join(root, pattern)
-      if (existsSync(join(dir, 'package.json'))) {
-        dirs.push(dir)
-      }
-    }
-  }
-
-  return dirs
-}
-
-function collectPackageDirs(dir: string, result: Array<string>): void {
-  if (existsSync(join(dir, 'package.json'))) {
-    result.push(dir)
-  }
-  let entries: Array<import('node:fs').Dirent>
-  try {
-    entries = readdirSync(dir, { withFileTypes: true })
-  } catch (err: unknown) {
-    console.error(
-      `Warning: could not read directory ${dir}: ${err instanceof Error ? err.message : err}`,
-    )
-    return
-  }
-  for (const entry of entries) {
-    if (
-      !entry.isDirectory() ||
-      entry.name === 'node_modules' ||
-      entry.name.startsWith('.')
-    )
-      continue
-    collectPackageDirs(join(dir, entry.name), result)
-  }
-}
-
-export function findWorkspaceRoot(start: string): string | null {
-  let dir = start
-
-  while (true) {
-    if (readWorkspacePatterns(dir)) {
-      return dir
-    }
-
-    const next = join(dir, '..')
-    if (next === dir) return null
-    dir = next
-  }
-}
-
-/**
- * Find workspace packages that contain at least one SKILL.md file.
- */
-export function findPackagesWithSkills(root: string): Array<string> {
-  const patterns = readWorkspacePatterns(root)
-  if (!patterns) return []
-
-  return resolveWorkspacePackages(root, patterns).filter((dir) => {
-    const skillsDir = join(dir, 'skills')
-    return existsSync(skillsDir) && findSkillFiles(skillsDir).length > 0
-  })
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/intent/src/setup.ts
+++ b/packages/intent/src/setup.ts
@@ -330,7 +330,9 @@ export function runEditPackageJson(root: string): EditPackageJsonResult {
           if (Array.isArray(parent.workspaces) || parent.workspaces?.packages) {
             return true
           }
-        } catch {}
+        } catch (err) {
+          console.error(`Warning: could not read ${parentPkg}: ${err instanceof Error ? err.message : err}`)
+        }
         return false
       }
       const next = join(dir, '..')

--- a/packages/intent/src/workspace-patterns.ts
+++ b/packages/intent/src/workspace-patterns.ts
@@ -7,9 +7,7 @@ function normalizeWorkspacePattern(pattern: string): string {
   return pattern.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '')
 }
 
-export function normalizeWorkspacePatterns(
-  patterns: Array<string>,
-): Array<string> {
+function normalizeWorkspacePatterns(patterns: Array<string>): Array<string> {
   return [
     ...new Set(patterns.map(normalizeWorkspacePattern).filter(Boolean)),
   ].sort((a, b) => a.localeCompare(b))
@@ -78,41 +76,51 @@ export function resolveWorkspacePackages(
   const dirs = new Set<string>()
 
   for (const pattern of normalizeWorkspacePatterns(patterns)) {
-    const base = pattern.replace(/\/\*\*?(\/\*)?$/, '')
-    const baseDir = join(root, base)
-    if (!existsSync(baseDir)) continue
-
-    if (pattern.includes('**')) {
-      collectPackageDirs(baseDir, dirs)
-    } else if (pattern.endsWith('/*')) {
-      let entries: Array<Dirent>
-      try {
-        entries = readdirSync(baseDir, { withFileTypes: true })
-      } catch {
-        continue
-      }
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue
-        const dir = join(baseDir, entry.name)
-        if (hasPackageJson(dir)) {
-          dirs.add(dir)
-        }
-      }
-    } else {
-      const dir = join(root, pattern)
-      if (hasPackageJson(dir)) {
-        dirs.add(dir)
-      }
-    }
+    resolveWorkspacePatternSegments(root, pattern.split('/'), dirs)
   }
 
   return [...dirs].sort((a, b) => a.localeCompare(b))
 }
 
-function collectPackageDirs(dir: string, result: Set<string>): void {
-  if (hasPackageJson(dir)) {
-    result.add(dir)
+function resolveWorkspacePatternSegments(
+  dir: string,
+  segments: Array<string>,
+  result: Set<string>,
+): void {
+  if (segments.length === 0) {
+    if (hasPackageJson(dir)) {
+      result.add(dir)
+    }
+    return
   }
+
+  const segment = segments[0]!
+  const remainingSegments = segments.slice(1)
+
+  if (segment === '**') {
+    resolveWorkspacePatternSegments(dir, remainingSegments, result)
+    for (const childDir of readChildDirectories(dir)) {
+      resolveWorkspacePatternSegments(childDir, segments, result)
+    }
+    return
+  }
+
+  if (segment === '*') {
+    for (const childDir of readChildDirectories(dir)) {
+      resolveWorkspacePatternSegments(childDir, remainingSegments, result)
+    }
+    return
+  }
+
+  const nextDir = join(dir, segment)
+  if (!existsSync(nextDir)) {
+    return
+  }
+
+  resolveWorkspacePatternSegments(nextDir, remainingSegments, result)
+}
+
+function readChildDirectories(dir: string): Array<string> {
   let entries: Array<Dirent>
   try {
     entries = readdirSync(dir, { withFileTypes: true })
@@ -120,18 +128,17 @@ function collectPackageDirs(dir: string, result: Set<string>): void {
     console.error(
       `Warning: could not read directory ${dir}: ${err instanceof Error ? err.message : err}`,
     )
-    return
+    return []
   }
-  for (const entry of entries) {
-    if (
-      !entry.isDirectory() ||
-      entry.name === 'node_modules' ||
-      entry.name.startsWith('.')
-    ) {
-      continue
-    }
-    collectPackageDirs(join(dir, entry.name), result)
-  }
+
+  return entries
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name !== 'node_modules' &&
+        !entry.name.startsWith('.'),
+    )
+    .map((entry) => join(dir, entry.name))
 }
 
 export function findWorkspaceRoot(start: string): string | null {

--- a/packages/intent/src/workspace-patterns.ts
+++ b/packages/intent/src/workspace-patterns.ts
@@ -1,0 +1,159 @@
+import { existsSync, readFileSync, readdirSync, type Dirent } from 'node:fs'
+import { join } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import { findSkillFiles } from './utils.js'
+
+function normalizeWorkspacePattern(pattern: string): string {
+  return pattern.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '')
+}
+
+export function normalizeWorkspacePatterns(
+  patterns: Array<string>,
+): Array<string> {
+  return [
+    ...new Set(patterns.map(normalizeWorkspacePattern).filter(Boolean)),
+  ].sort((a, b) => a.localeCompare(b))
+}
+
+function parseWorkspacePatterns(value: unknown): Array<string> | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  return normalizeWorkspacePatterns(
+    value.filter((pattern): pattern is string => typeof pattern === 'string'),
+  )
+}
+
+function hasPackageJson(dir: string): boolean {
+  return existsSync(join(dir, 'package.json'))
+}
+
+export function readWorkspacePatterns(root: string): Array<string> | null {
+  const pnpmWs = join(root, 'pnpm-workspace.yaml')
+  if (existsSync(pnpmWs)) {
+    try {
+      const config = parseYaml(readFileSync(pnpmWs, 'utf8')) as Record<
+        string,
+        unknown
+      >
+      const patterns = parseWorkspacePatterns(config.packages)
+      if (patterns) {
+        return patterns
+      }
+    } catch (err: unknown) {
+      console.error(
+        `Warning: failed to parse ${pnpmWs}: ${err instanceof Error ? err.message : err}`,
+      )
+    }
+  }
+
+  const pkgPath = join(root, 'package.json')
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+      const workspaces = parseWorkspacePatterns(pkg.workspaces)
+      if (workspaces) {
+        return workspaces
+      }
+
+      const workspacePackages = parseWorkspacePatterns(pkg.workspaces?.packages)
+      if (workspacePackages) {
+        return workspacePackages
+      }
+    } catch (err: unknown) {
+      console.error(
+        `Warning: failed to parse ${pkgPath}: ${err instanceof Error ? err.message : err}`,
+      )
+    }
+  }
+
+  return null
+}
+
+export function resolveWorkspacePackages(
+  root: string,
+  patterns: Array<string>,
+): Array<string> {
+  const dirs = new Set<string>()
+
+  for (const pattern of normalizeWorkspacePatterns(patterns)) {
+    const base = pattern.replace(/\/\*\*?(\/\*)?$/, '')
+    const baseDir = join(root, base)
+    if (!existsSync(baseDir)) continue
+
+    if (pattern.includes('**')) {
+      collectPackageDirs(baseDir, dirs)
+    } else if (pattern.endsWith('/*')) {
+      let entries: Array<Dirent>
+      try {
+        entries = readdirSync(baseDir, { withFileTypes: true })
+      } catch {
+        continue
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue
+        const dir = join(baseDir, entry.name)
+        if (hasPackageJson(dir)) {
+          dirs.add(dir)
+        }
+      }
+    } else {
+      const dir = join(root, pattern)
+      if (hasPackageJson(dir)) {
+        dirs.add(dir)
+      }
+    }
+  }
+
+  return [...dirs].sort((a, b) => a.localeCompare(b))
+}
+
+function collectPackageDirs(dir: string, result: Set<string>): void {
+  if (hasPackageJson(dir)) {
+    result.add(dir)
+  }
+  let entries: Array<Dirent>
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch (err: unknown) {
+    console.error(
+      `Warning: could not read directory ${dir}: ${err instanceof Error ? err.message : err}`,
+    )
+    return
+  }
+  for (const entry of entries) {
+    if (
+      !entry.isDirectory() ||
+      entry.name === 'node_modules' ||
+      entry.name.startsWith('.')
+    ) {
+      continue
+    }
+    collectPackageDirs(join(dir, entry.name), result)
+  }
+}
+
+export function findWorkspaceRoot(start: string): string | null {
+  let dir = start
+
+  while (true) {
+    if (readWorkspacePatterns(dir)) {
+      return dir
+    }
+
+    const next = join(dir, '..')
+    if (next === dir) return null
+    dir = next
+  }
+}
+
+export function findPackagesWithSkills(root: string): Array<string> {
+  const patterns = readWorkspacePatterns(root)
+  if (!patterns) return []
+
+  return resolveWorkspacePackages(root, patterns).filter((dir) => {
+    const skillsDir = join(dir, 'skills')
+    return existsSync(skillsDir) && findSkillFiles(skillsDir).length > 0
+  })
+}

--- a/packages/intent/src/workspace-patterns.ts
+++ b/packages/intent/src/workspace-patterns.ts
@@ -73,13 +73,25 @@ export function resolveWorkspacePackages(
   root: string,
   patterns: Array<string>,
 ): Array<string> {
-  const dirs = new Set<string>()
+  const includedDirs = new Set<string>()
+  const excludedDirs = new Set<string>()
 
   for (const pattern of normalizeWorkspacePatterns(patterns)) {
-    resolveWorkspacePatternSegments(root, pattern.split('/'), dirs)
+    if (pattern.startsWith('!')) {
+      resolveWorkspacePatternSegments(
+        root,
+        pattern.slice(1).split('/'),
+        excludedDirs,
+      )
+      continue
+    }
+
+    resolveWorkspacePatternSegments(root, pattern.split('/'), includedDirs)
   }
 
-  return [...dirs].sort((a, b) => a.localeCompare(b))
+  return [...includedDirs]
+    .filter((dir) => !excludedDirs.has(dir))
+    .sort((a, b) => a.localeCompare(b))
 }
 
 function resolveWorkspacePatternSegments(

--- a/packages/intent/src/workspace-patterns.ts
+++ b/packages/intent/src/workspace-patterns.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import type { Dirent } from 'node:fs'
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { findSkillFiles } from './utils.js'
 
@@ -19,15 +19,17 @@ function parseWorkspacePatterns(value: unknown): Array<string> | null {
     return null
   }
 
-  return normalizeWorkspacePatterns(
+  const normalized = normalizeWorkspacePatterns(
     value.filter((pattern): pattern is string => typeof pattern === 'string'),
   )
+  return normalized.length > 0 ? normalized : null
 }
 
 function hasPackageJson(dir: string): boolean {
   return existsSync(join(dir, 'package.json'))
 }
 
+/** Reads workspace patterns from pnpm-workspace.yaml (preferred) or package.json workspaces. Returns null if no workspace config is found. */
 export function readWorkspacePatterns(root: string): Array<string> | null {
   const pnpmWs = join(root, 'pnpm-workspace.yaml')
   if (existsSync(pnpmWs)) {
@@ -70,6 +72,7 @@ export function readWorkspacePatterns(root: string): Array<string> | null {
   return null
 }
 
+/** Resolves workspace glob patterns to package directories. Supports `*`, `**`, and `!` exclusion patterns. */
 export function resolveWorkspacePackages(
   root: string,
   patterns: Array<string>,
@@ -154,7 +157,11 @@ function readChildDirectories(dir: string): Array<string> {
     .map((entry) => join(dir, entry.name))
 }
 
+/** Walks up from `start` to find the nearest directory with a workspace config. */
 export function findWorkspaceRoot(start: string): string | null {
+  if (!isAbsolute(start)) {
+    throw new Error(`findWorkspaceRoot requires an absolute path, got: ${start}`)
+  }
   let dir = start
 
   while (true) {
@@ -168,6 +175,7 @@ export function findWorkspaceRoot(start: string): string | null {
   }
 }
 
+/** Finds workspace packages that contain at least one SKILL.md file. */
 export function findPackagesWithSkills(root: string): Array<string> {
   const patterns = readWorkspacePatterns(root)
   if (!patterns) return []

--- a/packages/intent/src/workspace-patterns.ts
+++ b/packages/intent/src/workspace-patterns.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, readdirSync, type Dirent } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import type { Dirent } from 'node:fs'
 import { join } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { findSkillFiles } from './utils.js'

--- a/packages/intent/tests/setup.test.ts
+++ b/packages/intent/tests/setup.test.ts
@@ -8,7 +8,7 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   runEditPackageJson,
   runEditPackageJsonAll,
@@ -181,6 +181,29 @@ describe('runEditPackageJson', () => {
 
     const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
     expect(pkg.files).not.toContain('!skills/_artifacts')
+
+    rmSync(monoRoot, { recursive: true, force: true })
+  })
+
+  it('warns when parent package.json is corrupted during monorepo detection', () => {
+    const monoRoot = mkdtempSync(join(tmpdir(), 'mono-root-'))
+    const pkgDir = join(monoRoot, 'packages', 'my-lib')
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(monoRoot, 'package.json'), '{invalid json')
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: '@scope/my-lib' }, null, 2),
+    )
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      runEditPackageJson(pkgDir)
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(join(monoRoot, 'package.json')),
+      )
+    } finally {
+      spy.mockRestore()
+    }
 
     rmSync(monoRoot, { recursive: true, force: true })
   })

--- a/packages/intent/tests/workspace-patterns.test.ts
+++ b/packages/intent/tests/workspace-patterns.test.ts
@@ -1,9 +1,9 @@
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  normalizeWorkspacePatterns,
+  readWorkspacePatterns,
   resolveWorkspacePackages,
 } from '../src/workspace-patterns.js'
 
@@ -24,24 +24,39 @@ function writePackage(root: string, ...parts: Array<string>): void {
   )
 }
 
+function writeDir(root: string, ...parts: Array<string>): void {
+  mkdirSync(join(root, ...parts), { recursive: true })
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
   }
 })
 
-describe('normalizeWorkspacePatterns', () => {
+describe('readWorkspacePatterns', () => {
   it('normalizes, drops empty patterns, dedupes, and sorts them', () => {
-    expect(
-      normalizeWorkspacePatterns([
-        '',
-        './apps/*/packages/*/',
-        './packages/*/',
-        'apps/*',
-        'packages\\*',
-        'apps/*',
-      ]),
-    ).toEqual(['apps/*', 'apps/*/packages/*', 'packages/*'])
+    const root = createRoot()
+
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        workspaces: [
+          '',
+          './apps/*/packages/*/',
+          './packages/*/',
+          'apps/*',
+          'packages\\*',
+          'apps/*',
+        ],
+      }),
+    )
+
+    expect(readWorkspacePatterns(root)).toEqual([
+      'apps/*',
+      'apps/*/packages/*',
+      'packages/*',
+    ])
   })
 })
 
@@ -62,5 +77,63 @@ describe('resolveWorkspacePackages', () => {
       join(root, 'packages', 'a-lib'),
       join(root, 'packages', 'b-lib'),
     ])
+  })
+
+  it('resolves nested workspace patterns segment by segment', () => {
+    const root = createRoot()
+
+    writePackage(root, 'apps', 'mobile', 'packages', 'native')
+    writePackage(root, 'apps', 'web', 'packages', 'app')
+    writePackage(root, 'apps', 'web', 'packages', 'ui')
+    writeDir(root, 'apps', 'docs', 'packages', 'guides')
+
+    expect(resolveWorkspacePackages(root, ['apps/*/packages/*'])).toEqual([
+      join(root, 'apps', 'mobile', 'packages', 'native'),
+      join(root, 'apps', 'web', 'packages', 'app'),
+      join(root, 'apps', 'web', 'packages', 'ui'),
+    ])
+  })
+
+  it('treats normalized nested patterns identically', () => {
+    const root = createRoot()
+
+    writePackage(root, 'apps', 'web', 'packages', 'app')
+
+    expect(
+      resolveWorkspacePackages(root, [
+        './apps/*/packages/*/',
+        'apps\\*\\packages\\*',
+      ]),
+    ).toEqual([join(root, 'apps', 'web', 'packages', 'app')])
+  })
+
+  it('supports recursive ** segments across multiple directory levels', () => {
+    const root = createRoot()
+
+    writePackage(root, 'apps', 'mobile', 'packages', 'native')
+    writePackage(root, 'apps', 'web', 'features', 'packages', 'charts')
+    writePackage(root, 'apps', 'web', 'packages', 'app')
+    writeDir(root, 'apps', 'web', 'drafts', 'packages', 'notes')
+
+    expect(resolveWorkspacePackages(root, ['apps/**/packages/*'])).toEqual([
+      join(root, 'apps', 'mobile', 'packages', 'native'),
+      join(root, 'apps', 'web', 'features', 'packages', 'charts'),
+      join(root, 'apps', 'web', 'packages', 'app'),
+    ])
+  })
+
+  it('ignores nonexistent literal segments and directories without package.json', () => {
+    const root = createRoot()
+
+    writePackage(root, 'apps', 'web', 'packages', 'app')
+    writeDir(root, 'apps', 'web', 'packages', 'docs')
+
+    expect(
+      resolveWorkspacePackages(root, [
+        '',
+        'apps/admin/packages/*',
+        'apps/web/packages/*',
+      ]),
+    ).toEqual([join(root, 'apps', 'web', 'packages', 'app')])
   })
 })

--- a/packages/intent/tests/workspace-patterns.test.ts
+++ b/packages/intent/tests/workspace-patterns.test.ts
@@ -1,0 +1,66 @@
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  normalizeWorkspacePatterns,
+  resolveWorkspacePackages,
+} from '../src/workspace-patterns.js'
+
+const roots: Array<string> = []
+
+function createRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'workspace-patterns-test-'))
+  roots.push(root)
+  return root
+}
+
+function writePackage(root: string, ...parts: Array<string>): void {
+  const dir = join(root, ...parts)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: parts.join('/') }),
+  )
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('normalizeWorkspacePatterns', () => {
+  it('normalizes, drops empty patterns, dedupes, and sorts them', () => {
+    expect(
+      normalizeWorkspacePatterns([
+        '',
+        './apps/*/packages/*/',
+        './packages/*/',
+        'apps/*',
+        'packages\\*',
+        'apps/*',
+      ]),
+    ).toEqual(['apps/*', 'apps/*/packages/*', 'packages/*'])
+  })
+})
+
+describe('resolveWorkspacePackages', () => {
+  it('dedupes and sorts resolved package roots for simple patterns', () => {
+    const root = createRoot()
+
+    writePackage(root, 'packages', 'b-lib')
+    writePackage(root, 'packages', 'a-lib')
+
+    expect(
+      resolveWorkspacePackages(root, [
+        './packages/*/',
+        'packages\\*',
+        'packages/*',
+      ]),
+    ).toEqual([
+      join(root, 'packages', 'a-lib'),
+      join(root, 'packages', 'b-lib'),
+    ])
+  })
+})

--- a/packages/intent/tests/workspace-patterns.test.ts
+++ b/packages/intent/tests/workspace-patterns.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -13,7 +13,7 @@ const roots: Array<string> = []
 const cwdStack: Array<string> = []
 
 function createRoot(): string {
-  const root = mkdtempSync(join(tmpdir(), 'workspace-patterns-test-'))
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'workspace-patterns-test-')))
   roots.push(root)
   return root
 }
@@ -69,6 +69,59 @@ describe('readWorkspacePatterns', () => {
       'apps/*/packages/*',
       'packages/*',
     ])
+  })
+
+  it('reads and normalizes patterns from pnpm-workspace.yaml', () => {
+    const root = createRoot()
+
+    writeFileSync(
+      join(root, 'pnpm-workspace.yaml'),
+      'packages:\n  - ./packages/*/\n  - apps/*\n  - ./packages/*/\n',
+    )
+
+    expect(readWorkspacePatterns(root)).toEqual(['apps/*', 'packages/*'])
+  })
+
+  it('prefers pnpm-workspace.yaml over package.json workspaces', () => {
+    const root = createRoot()
+
+    writeFileSync(
+      join(root, 'pnpm-workspace.yaml'),
+      'packages:\n  - libs/*\n',
+    )
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ workspaces: ['packages/*'] }),
+    )
+
+    expect(readWorkspacePatterns(root)).toEqual(['libs/*'])
+  })
+
+  it('reads patterns from Yarn classic workspaces.packages format', () => {
+    const root = createRoot()
+
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ workspaces: { packages: ['packages/*', 'apps/*'] } }),
+    )
+
+    expect(readWorkspacePatterns(root)).toEqual(['apps/*', 'packages/*'])
+  })
+
+  it('returns null when no workspace config exists', () => {
+    const root = createRoot()
+    expect(readWorkspacePatterns(root)).toBeNull()
+  })
+
+  it('returns null when all patterns normalize to empty strings', () => {
+    const root = createRoot()
+
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ workspaces: ['', ''] }),
+    )
+
+    expect(readWorkspacePatterns(root)).toBeNull()
   })
 })
 
@@ -158,6 +211,33 @@ describe('resolveWorkspacePackages', () => {
     expect(
       resolveWorkspacePackages(root, ['packages/*', '!packages/excluded']),
     ).toEqual([join(root, 'packages', 'alpha')])
+  })
+
+  it('normalizes exclusion patterns with ./ and backslash prefixes', () => {
+    const root = createRoot()
+
+    writePackage(root, 'packages', 'alpha')
+    writePackage(root, 'packages', 'beta')
+    writePackage(root, 'packages', 'excluded')
+
+    expect(
+      resolveWorkspacePackages(root, ['packages/*', '!./packages/excluded']),
+    ).toEqual([join(root, 'packages', 'alpha'), join(root, 'packages', 'beta')])
+
+    expect(
+      resolveWorkspacePackages(root, ['packages/*', '!packages\\excluded']),
+    ).toEqual([join(root, 'packages', 'alpha'), join(root, 'packages', 'beta')])
+  })
+})
+
+describe('findWorkspaceRoot', () => {
+  it('returns null when no workspace config exists in any ancestor', () => {
+    const root = createRoot()
+    expect(findWorkspaceRoot(root)).toBeNull()
+  })
+
+  it('throws on relative paths', () => {
+    expect(() => findWorkspaceRoot('relative/path')).toThrow()
   })
 })
 

--- a/packages/intent/tests/workspace-patterns.test.ts
+++ b/packages/intent/tests/workspace-patterns.test.ts
@@ -3,11 +3,14 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  findPackagesWithSkills,
+  findWorkspaceRoot,
   readWorkspacePatterns,
   resolveWorkspacePackages,
 } from '../src/workspace-patterns.js'
 
 const roots: Array<string> = []
+const cwdStack: Array<string> = []
 
 function createRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'workspace-patterns-test-'))
@@ -29,10 +32,19 @@ function writeDir(root: string, ...parts: Array<string>): void {
 }
 
 afterEach(() => {
+  if (cwdStack.length > 0) {
+    process.chdir(cwdStack.pop()!)
+  }
+
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
   }
 })
+
+function withCwd(dir: string): void {
+  cwdStack.push(process.cwd())
+  process.chdir(dir)
+}
 
 describe('readWorkspacePatterns', () => {
   it('normalizes, drops empty patterns, dedupes, and sorts them', () => {
@@ -135,5 +147,49 @@ describe('resolveWorkspacePackages', () => {
         'apps/web/packages/*',
       ]),
     ).toEqual([join(root, 'apps', 'web', 'packages', 'app')])
+  })
+
+  it('applies exclusion patterns from pnpm-workspace.yaml', () => {
+    const root = createRoot()
+
+    writePackage(root, 'packages', 'alpha')
+    writePackage(root, 'packages', 'excluded')
+
+    expect(
+      resolveWorkspacePackages(root, ['packages/*', '!packages/excluded']),
+    ).toEqual([join(root, 'packages', 'alpha')])
+  })
+})
+
+describe('workspace helpers', () => {
+  it('resolves pnpm workspace roots and returns only packages with skills', () => {
+    const root = createRoot()
+
+    writeFileSync(
+      join(root, 'pnpm-workspace.yaml'),
+      ['packages:', '  - packages/*', "  - '!packages/excluded'"].join('\n'),
+    )
+    writePackage(root, 'packages', 'alpha')
+    writePackage(root, 'packages', 'beta')
+    writePackage(root, 'packages', 'excluded')
+    writeDir(root, 'packages', 'alpha', 'skills', 'core', 'setup')
+    writeDir(root, 'packages', 'excluded', 'skills', 'core', 'setup')
+    writeFileSync(
+      join(root, 'packages', 'alpha', 'skills', 'core', 'setup', 'SKILL.md'),
+      '# alpha skill\n',
+    )
+    writeFileSync(
+      join(root, 'packages', 'excluded', 'skills', 'core', 'setup', 'SKILL.md'),
+      '# excluded skill\n',
+    )
+
+    const nestedDir = join(root, 'packages', 'alpha', 'src', 'nested')
+    writeDir(root, 'packages', 'alpha', 'src', 'nested')
+    withCwd(nestedDir)
+
+    expect(findWorkspaceRoot(process.cwd())).toBe(root)
+    expect(findPackagesWithSkills(root)).toEqual([
+      join(root, 'packages', 'alpha'),
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- replace the workspace suffix-stripping logic with segment-by-segment resolution for literal segments, `*`, and `**`
- normalize workspace patterns before resolution and return deduped, stably sorted package roots
- support exclusion patterns from workspace config by subtracting `!`-prefixed matches from resolved package roots
- extract the shared workspace discovery helpers into a dedicated module and update internal consumers to use it directly

## Notes

This fixes nested workspace patterns like `apps/*/packages/*`, which were previously resolved incorrectly because the old resolver stripped glob suffixes and treated the remaining path as literal.

It also makes pnpm-style exclusion patterns work during workspace package resolution.

Fixes #88 and lays the groundwork for later shared project/context resolution work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace package discovery for nested glob patterns; patterns are now normalized, deduplicated, sorted and support both * and **.
  * Improved monorepo detection error handling to emit warnings with the failing parent path when configuration parsing fails.
* **Tests**
  * Added tests covering pattern parsing, nested/recursive resolution, exclusions, and filtering packages with skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->