### PR TITLE
fix: discover transitive skills under pnpm's isolated linker

### DIFF
--- a/.changeset/tangy-plants-hunt.md
+++ b/.changeset/tangy-plants-hunt.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Fix transitive skill discovery under pnpm's isolated linker. Skills shipped by a transitive dependency of a skill-bearing direct dependency were not discovered… Each package's dependencies are now resolved from its realpath, where pnpm resolution succeeds. Hoisted (npm/yarn/bun) layouts are unaffected.

--- a/packages/intent/src/discovery/walk.ts
+++ b/packages/intent/src/discovery/walk.ts
@@ -64,7 +64,7 @@ export function createDependencyWalker(opts: CreateDependencyWalkerOptions) {
     if (walkVisited.has(pkgKey)) return
     walkVisited.add(pkgKey)
 
-    const pkgJson = opts.readPkgJson(pkgKey)
+    const pkgJson = opts.readPkgJson(pkgDir)
     if (!pkgJson) {
       opts.warnings.push(
         `Could not read package.json for ${pkgName} (skipping dependency walk)`,

--- a/packages/intent/src/discovery/walk.ts
+++ b/packages/intent/src/discovery/walk.ts
@@ -58,11 +58,13 @@ export function createDependencyWalker(opts: CreateDependencyWalkerOptions) {
   }
 
   function walkDeps(pkgDir: string, pkgName: string): void {
+    // Resolve from the realpath: a pnpm symlink path can't resolve store-only
+    // transitive deps, and walkVisited dedups on realpath so no later retry.
     const pkgKey = opts.getFsIdentity(pkgDir)
     if (walkVisited.has(pkgKey)) return
     walkVisited.add(pkgKey)
 
-    const pkgJson = opts.readPkgJson(pkgDir)
+    const pkgJson = opts.readPkgJson(pkgKey)
     if (!pkgJson) {
       opts.warnings.push(
         `Could not read package.json for ${pkgName} (skipping dependency walk)`,
@@ -70,7 +72,7 @@ export function createDependencyWalker(opts: CreateDependencyWalkerOptions) {
       return
     }
 
-    walkDepsOf(pkgJson, pkgDir)
+    walkDepsOf(pkgJson, pkgKey)
   }
 
   function walkKnownPackages(): void {

--- a/packages/intent/tests/scanner.test.ts
+++ b/packages/intent/tests/scanner.test.ts
@@ -194,6 +194,173 @@ describe('scanForIntents', () => {
     expect(result.packages[0]!.name).toBe('my-lib')
   })
 
+  it('discovers transitive skills of a skill-bearing direct dep under pnpm isolated linker (#153)', () => {
+    // pnpm isolated layout: a store-only transitive dep (start-core) reached
+    // only through its skill-bearing parent's (react-start) store dir.
+    writeFileSync(join(root, 'pnpm-lock.yaml'), '')
+    writeJson(join(root, 'package.json'), {
+      name: 'consumer',
+      version: '1.0.0',
+      dependencies: { '@scope/react-start': '1.0.0' },
+    })
+
+    const pnpmDir = join(root, 'node_modules', '.pnpm')
+
+    const startCoreStore = createDir(
+      pnpmDir,
+      '@scope+start-core@1.0.0',
+      'node_modules',
+      '@scope',
+      'start-core',
+    )
+    writeJson(join(startCoreStore, 'package.json'), {
+      name: '@scope/start-core',
+      version: '1.0.0',
+      intent: { version: 1, repo: 'scope/start-core', docs: 'docs/' },
+    })
+    writeSkillMd(createDir(startCoreStore, 'skills', 'start-core'), {
+      name: 'start-core',
+      description: 'Start core skill',
+      type: 'core',
+    })
+
+    const reactStartStore = createDir(
+      pnpmDir,
+      '@scope+react-start@1.0.0',
+      'node_modules',
+      '@scope',
+      'react-start',
+    )
+    writeJson(join(reactStartStore, 'package.json'), {
+      name: '@scope/react-start',
+      version: '1.0.0',
+      intent: { version: 1, repo: 'scope/react-start', docs: 'docs/' },
+      dependencies: { '@scope/start-core': '1.0.0' },
+    })
+    writeSkillMd(createDir(reactStartStore, 'skills', 'react-start'), {
+      name: 'react-start',
+      description: 'React start skill',
+      type: 'core',
+    })
+
+    // start-core symlinked as a sibling inside react-start's store dir only.
+    createDir(pnpmDir, '@scope+react-start@1.0.0', 'node_modules', '@scope')
+    symlinkSync(
+      startCoreStore,
+      join(
+        pnpmDir,
+        '@scope+react-start@1.0.0',
+        'node_modules',
+        '@scope',
+        'start-core',
+      ),
+    )
+
+    // react-start hoisted to the top-level node_modules; start-core is not.
+    createDir(root, 'node_modules', '@scope')
+    symlinkSync(
+      reactStartStore,
+      join(root, 'node_modules', '@scope', 'react-start'),
+    )
+
+    const result = scanForIntents(root)
+
+    const names = result.packages.map((p) => p.name)
+    expect(names).toContain('@scope/react-start')
+    expect(names).toContain('@scope/start-core')
+
+    const startCore = result.packages.find(
+      (p) => p.name === '@scope/start-core',
+    )
+    expect(startCore!.skills.map((s) => s.name)).toContain('start-core')
+
+    // One installed version must not be reported as a version conflict.
+    expect(result.conflicts).toEqual([])
+  })
+
+  it('discovers transitive skills when the dep resolves through a second symlink hop (#153 residual risk)', () => {
+    // The transitive dep is reached through two symlink hops; realpathSync must
+    // collapse the whole chain, not just one hop.
+    writeFileSync(join(root, 'pnpm-lock.yaml'), '')
+    writeJson(join(root, 'package.json'), {
+      name: 'consumer',
+      version: '1.0.0',
+      dependencies: { '@scope/react-start': '1.0.0' },
+    })
+
+    const pnpmDir = join(root, 'node_modules', '.pnpm')
+
+    const startCoreReal = createDir(
+      pnpmDir,
+      '@scope+start-core@1.0.0',
+      'node_modules',
+      '@scope',
+      'start-core',
+    )
+    writeJson(join(startCoreReal, 'package.json'), {
+      name: '@scope/start-core',
+      version: '1.0.0',
+      intent: { version: 1, repo: 'scope/start-core', docs: 'docs/' },
+    })
+    writeSkillMd(createDir(startCoreReal, 'skills', 'start-core'), {
+      name: 'start-core',
+      description: 'Start core skill',
+      type: 'core',
+    })
+
+    // Intermediate symlink hop: a separate link that targets the real store dir.
+    const intermediateScope = createDir(root, '.intermediate', '@scope')
+    const intermediateStartCore = join(intermediateScope, 'start-core')
+    symlinkSync(startCoreReal, intermediateStartCore)
+
+    const reactStartStore = createDir(
+      pnpmDir,
+      '@scope+react-start@1.0.0',
+      'node_modules',
+      '@scope',
+      'react-start',
+    )
+    writeJson(join(reactStartStore, 'package.json'), {
+      name: '@scope/react-start',
+      version: '1.0.0',
+      intent: { version: 1, repo: 'scope/react-start', docs: 'docs/' },
+      dependencies: { '@scope/start-core': '1.0.0' },
+    })
+    writeSkillMd(createDir(reactStartStore, 'skills', 'react-start'), {
+      name: 'react-start',
+      description: 'React start skill',
+      type: 'core',
+    })
+
+    // react-start's sibling link -> intermediate link -> real store dir.
+    createDir(pnpmDir, '@scope+react-start@1.0.0', 'node_modules', '@scope')
+    symlinkSync(
+      intermediateStartCore,
+      join(
+        pnpmDir,
+        '@scope+react-start@1.0.0',
+        'node_modules',
+        '@scope',
+        'start-core',
+      ),
+    )
+
+    createDir(root, 'node_modules', '@scope')
+    symlinkSync(
+      reactStartStore,
+      join(root, 'node_modules', '@scope', 'react-start'),
+    )
+
+    const result = scanForIntents(root)
+
+    const startCore = result.packages.find(
+      (p) => p.name === '@scope/start-core',
+    )
+    expect(startCore).toBeDefined()
+    expect(startCore!.skills.map((s) => s.name)).toContain('start-core')
+    expect(result.conflicts).toEqual([])
+  })
+
   it('discovers sub-skills', () => {
     const pkgDir = createDir(root, 'node_modules', '@tanstack', 'db')
     writeJson(join(pkgDir, 'package.json'), {


### PR DESCRIPTION
### Problem
Under pnpm's isolated linker, skills from a **transitive dep of a skill-bearing direct dep** weren't discovered. In the repro, `@tanstack/react-start` (direct, ships skills) depends on `@tanstack/start-client-core` and `@tanstack/start-server-core` (both ship skills) — neither surfaced in `intent list`, and `intent load` for them failed. The tell: `@tanstack/router-core` *was* found, because its parents ship no skills.

### Root cause
The walk dedups on realpath but visited the parent via its **symlink** path first. Resolving deps from that symlink dir fails (the `.pnpm` store isn't in its ancestor chain), so the transitive cores were skipped. The parent's **realpath** was then recorded in `walkVisited`, so the later real-path visit that *would* resolve correctly was deduped away. A package's skills were hidden **because** its parent ships skills.

### Fix
Resolve each package's deps from its **realpath** (already the `walkVisited` key) instead of the symlink path. One-call change in `walkDeps`.
- All three dedup layers and the public `scanForIntents` signature preserved.
- No `import()`/`require()` of discovered code.
- No-op for hoisted layouts (npm/yarn/bun).

Closes #153 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transitive skill discovery when using pnpm’s isolated linker so skills from transitive dependencies are correctly found; npm/yarn/bun behavior unchanged.
* **Tests**
  * Added tests covering pnpm isolated linking and multi-symlink resolution to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->