### PR TITLE
chore: set pnpm minimum release age to 1440

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 cleanupUnusedCatalogs: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true


### PR DESCRIPTION
Follow-up to #182 after merge. The merged branch left pnpm-workspace.yaml with minimumReleaseAge: 1; this raises it to 1440.