### PR TITLE
perf: batch of low-risk fixes for hangs and unnecessary FS work

### DIFF
--- a/.changeset/nine-pigs-laugh.md
+++ b/.changeset/nine-pigs-laugh.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/intent': patch
+---
+
+Fix potential hangs on slow or large environments:
+
+- Bound the npm registry staleness check with a request timeout so `intent list` and other staleness checks can't hang indefinitely on a slow or unreachable registry.
+- Bound global package-manager detection with a command timeout so it can't hang indefinitely when the environment's global `node_modules` is slow to resolve.
+- Avoid enumerating a workspace package's entire skill tree just to check whether it has any skills, reducing filesystem work in large monorepos.

--- a/benchmarks/intent/startup.bench.ts
+++ b/benchmarks/intent/startup.bench.ts
@@ -12,7 +12,10 @@ const coldStartBenchOptions = {
 }
 
 function runNode(args: Array<string>): void {
-  const result = spawnSync(process.execPath, args, { stdio: 'ignore' })
+  const result = spawnSync(process.execPath, args, {
+    stdio: 'ignore',
+    timeout: 10_000,
+  })
   if (result.status !== 0) {
     throw new Error(
       `spawn ${[process.execPath, ...args].join(' ')} exited with code ${result.status}`,

--- a/benchmarks/intent/startup.bench.ts
+++ b/benchmarks/intent/startup.bench.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { bench, describe } from 'vitest'
+
+const cliPath = fileURLToPath(
+  new URL('../../packages/intent/dist/cli.mjs', import.meta.url),
+)
+
+const coldStartBenchOptions = {
+  warmupIterations: 20,
+  time: 3_000,
+}
+
+function runNode(args: Array<string>): void {
+  const result = spawnSync(process.execPath, args, { stdio: 'ignore' })
+  if (result.status !== 0) {
+    throw new Error(
+      `spawn ${[process.execPath, ...args].join(' ')} exited with code ${result.status}`,
+    )
+  }
+}
+
+describe('cold start', () => {
+  bench(
+    'empty node process (baseline)',
+    () => {
+      runNode(['-e', ''])
+    },
+    coldStartBenchOptions,
+  )
+
+  bench(
+    'intent --help',
+    () => {
+      runNode([cliPath, '--help'])
+    },
+    coldStartBenchOptions,
+  )
+})

--- a/packages/intent/src/setup/workspace-patterns.ts
+++ b/packages/intent/src/setup/workspace-patterns.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { parse as parseJsonc } from 'jsonc-parser'
 import { parse as parseYaml } from 'yaml'
-import { findSkillFiles } from '../shared/utils.js'
+import { hasAnySkillFile } from '../shared/utils.js'
 import type { ParseError } from 'jsonc-parser'
 
 function normalizeWorkspacePattern(pattern: string): string {
@@ -227,7 +227,7 @@ export function getWorkspaceInfo(root: string): WorkspaceInfo | null {
   const packageDirs = readWorkspacePackageDirs(root) ?? []
   const packageDirsWithSkills = packageDirs.filter((dir) => {
     const skillsDir = join(dir, 'skills')
-    return existsSync(skillsDir) && findSkillFiles(skillsDir).length > 0
+    return existsSync(skillsDir) && hasAnySkillFile(skillsDir)
   })
   const info = {
     root,

--- a/packages/intent/src/shared/utils.ts
+++ b/packages/intent/src/shared/utils.ts
@@ -115,6 +115,30 @@ function collectSkillFiles(
 }
 
 /**
+ * Like `findSkillFiles`, but stops at the first SKILL.md found instead of
+ * enumerating the whole tree.
+ */
+export function hasAnySkillFile(dir: string, fs: ReadFs = nodeReadFs): boolean {
+  let entries: Array<Dirent<string>>
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true, encoding: 'utf8' })
+  } catch {
+    return false
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (hasAnySkillFile(fullPath, fs)) return true
+    } else if (entry.name === 'SKILL.md') {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
  * Read dependencies and peerDependencies (and optionally devDependencies) from
  * a parsed package.json object.
  */

--- a/packages/intent/src/shared/utils.ts
+++ b/packages/intent/src/shared/utils.ts
@@ -232,6 +232,8 @@ export function listNestedNodeModulesPackageDirs(
   return packageDirs
 }
 
+const GLOBAL_NODE_MODULES_COMMAND_TIMEOUT_MS = 5_000
+
 export function detectGlobalNodeModules(packageManager: string): {
   path: string | null
   source?: string
@@ -267,6 +269,7 @@ export function detectGlobalNodeModules(packageManager: string): {
       const output = execFileSync(candidate.command, candidate.args, {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: GLOBAL_NODE_MODULES_COMMAND_TIMEOUT_MS,
       }).trim()
       if (!output) continue
 

--- a/packages/intent/src/staleness/check.ts
+++ b/packages/intent/src/staleness/check.ts
@@ -90,10 +90,13 @@ function readLocalVersion(packageDir: string): string | null {
   }
 }
 
+const NPM_REGISTRY_FETCH_TIMEOUT_MS = 5_000
+
 async function fetchNpmVersion(packageName: string): Promise<string | null> {
   try {
     const res = await fetch(
       `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`,
+      { signal: AbortSignal.timeout(NPM_REGISTRY_FETCH_TIMEOUT_MS) },
     )
     if (!res.ok) return null
     const data = (await res.json()) as Record<string, unknown>


### PR DESCRIPTION
## Summary

Batches four low-risk, independently-scoped performance/robustness fixes identified in the TanStack Intent perf audit. Each was implemented and verified as an isolated commit.

- **Bound npm registry fetch with a timeout** (`c2dd89c`) — the staleness check's `fetchNpmVersion` had no timeout, so `intent list` and other staleness checks could hang indefinitely against a slow or unreachable registry. Now aborts via `AbortSignal.timeout(5_000)`.
- **Bound global package-manager detection with a timeout** (`975275b`) — `detectGlobalNodeModules`'s `execFileSync` call had no timeout, so it could hang indefinitely if the environment's global `node_modules` resolution stalled. Added `GLOBAL_NODE_MODULES_COMMAND_TIMEOUT_MS` and passed `timeout` to `execFileSync`.
- **Early-exit skill-file check** (`17fb035`) — `getWorkspaceInfo` called `findSkillFiles(...).length > 0`, which fully enumerates every skill file in a package just to check existence. Added `hasAnySkillFile()`, which returns on the first match, reducing unnecessary filesystem walks in large monorepos.
- **Process-level cold-start benchmark** (`ec6475b`) — existing benches (`list`/`load`/`stale`/`validate`) reuse a warm module graph via in-process `main()` calls, so none measured actual process cold start. Added `benchmarks/intent/startup.bench.ts`, which spawns a fresh Node process per sample (`intent --help` vs. an empty-node baseline) to isolate intent's own startup overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in slow or large environments by preventing certain checks from hanging indefinitely.
  * Added time limits to registry lookups and environment detection steps so the app can continue instead of waiting forever.
  * Reduced unnecessary filesystem scanning in large workspaces, helping speed up startup and related commands.

* **Tests**
  * Added a benchmark to measure cold-start performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->