### PR TITLE
Harden scanner trust boundaries: non-suppressible permit-all banner + reject in-node_modules PnP runtime

### DIFF
--- a/.changeset/fruity-ghosts-brake.md
+++ b/.changeset/fruity-ghosts-brake.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Refuse to load a Yarn PnP runtime resolved from within node_modules; only a project root or ancestor .pnp.cjs is trusted.

--- a/packages/intent/src/discovery/scanner.ts
+++ b/packages/intent/src/discovery/scanner.ts
@@ -91,6 +91,10 @@ function findPnpFile(start: string): string | null {
   return null
 }
 
+export function isPnpRuntimeWithinNodeModules(pnpPath: string): boolean {
+  return resolve(pnpPath).split(sep).includes('node_modules')
+}
+
 function assertLocalNodeModulesSupported(root: string): void {
   if (
     existsSync(join(root, 'deno.json')) &&
@@ -105,6 +109,12 @@ function assertLocalNodeModulesSupported(root: string): void {
 function loadPnpApi(root: string): LoadedPnp | null {
   const pnpPath = findPnpFile(root)
   if (!pnpPath) return null
+
+  if (isPnpRuntimeWithinNodeModules(pnpPath)) {
+    throw new Error(
+      `Refusing to load a Yarn PnP runtime resolved from within node_modules: ${pnpPath}. Only a project root or ancestor .pnp.cjs is trusted.`,
+    )
+  }
 
   const moduleApi = requireFromHere('node:module') as NodeModuleInternals
   const originalResolveFilename = moduleApi._resolveFilename

--- a/packages/intent/tests/cli-output.test.ts
+++ b/packages/intent/tests/cli-output.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ALLOW_ALL_NOTICE,
+  printNotices,
+  printWarnings,
+} from '../src/shared/cli-output.js'
+
+const OTHER_NOTICE = 'intent.skills is empty — no skill sources are permitted.'
+
+describe('printNotices — ALLOW_ALL_NOTICE is non-suppressible', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let logSpy: ReturnType<typeof vi.spyOn>
+  const previousEnv = process.env.INTENT_NO_NOTICES
+
+  beforeEach(() => {
+    delete process.env.INTENT_NO_NOTICES
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    logSpy.mockRestore()
+    if (previousEnv === undefined) delete process.env.INTENT_NO_NOTICES
+    else process.env.INTENT_NO_NOTICES = previousEnv
+  })
+
+  function stderr(): string {
+    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n')
+  }
+
+  it('prints the permit-all banner even when noNotices is set, and suppresses the rest', () => {
+    printNotices([OTHER_NOTICE, ALLOW_ALL_NOTICE], { noNotices: true })
+
+    const output = stderr()
+    expect(output).toContain(ALLOW_ALL_NOTICE)
+    expect(output).not.toContain(OTHER_NOTICE)
+  })
+
+  it('prints the permit-all banner even when INTENT_NO_NOTICES=1', () => {
+    process.env.INTENT_NO_NOTICES = '1'
+
+    printNotices([OTHER_NOTICE, ALLOW_ALL_NOTICE])
+
+    const output = stderr()
+    expect(output).toContain(ALLOW_ALL_NOTICE)
+    expect(output).not.toContain(OTHER_NOTICE)
+  })
+
+  it('prints every notice when suppression is off', () => {
+    printNotices([OTHER_NOTICE, ALLOW_ALL_NOTICE])
+
+    const output = stderr()
+    expect(output).toContain(ALLOW_ALL_NOTICE)
+    expect(output).toContain(OTHER_NOTICE)
+  })
+
+  it('prints nothing when only non-banner notices are suppressed', () => {
+    printNotices([OTHER_NOTICE], { noNotices: true })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('prints nothing for an empty notice list', () => {
+    printNotices([], { noNotices: true })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes the banner through the notices (stderr) channel, never the warnings channel', () => {
+    printNotices([ALLOW_ALL_NOTICE], { noNotices: true })
+    printWarnings([])
+
+    expect(stderr()).toContain(ALLOW_ALL_NOTICE)
+    const stdout = logSpy.mock.calls.map((call) => call.join(' ')).join('\n')
+    expect(stdout).not.toContain(ALLOW_ALL_NOTICE)
+  })
+})

--- a/packages/intent/tests/cli-output.test.ts
+++ b/packages/intent/tests/cli-output.test.ts
@@ -26,7 +26,9 @@ describe('printNotices — ALLOW_ALL_NOTICE is non-suppressible', () => {
   })
 
   function stderr(): string {
-    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n')
+    return errorSpy.mock.calls
+      .map((call: Array<unknown>) => call.join(' '))
+      .join('\n')
   }
 
   it('prints the permit-all banner even when noNotices is set, and suppresses the rest', () => {
@@ -72,7 +74,9 @@ describe('printNotices — ALLOW_ALL_NOTICE is non-suppressible', () => {
     printWarnings([])
 
     expect(stderr()).toContain(ALLOW_ALL_NOTICE)
-    const stdout = logSpy.mock.calls.map((call) => call.join(' ')).join('\n')
+    const stdout = logSpy.mock.calls
+      .map((call: Array<unknown>) => call.join(' '))
+      .join('\n')
     expect(stdout).not.toContain(ALLOW_ALL_NOTICE)
   })
 })

--- a/packages/intent/tests/pnp-trust-boundary.test.ts
+++ b/packages/intent/tests/pnp-trust-boundary.test.ts
@@ -1,0 +1,40 @@
+import { sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isPnpRuntimeWithinNodeModules } from '../src/discovery/scanner.js'
+
+const abs = (...segments: Array<string>): string => sep + segments.join(sep)
+
+describe('isPnpRuntimeWithinNodeModules', () => {
+  it('trusts a project-root .pnp.cjs', () => {
+    expect(isPnpRuntimeWithinNodeModules(abs('app', '.pnp.cjs'))).toBe(false)
+  })
+
+  it('trusts an ancestor .pnp.cjs above the project', () => {
+    expect(isPnpRuntimeWithinNodeModules(abs('.pnp.cjs'))).toBe(false)
+    expect(
+      isPnpRuntimeWithinNodeModules(abs('workspace', 'app', '..', '.pnp.cjs')),
+    ).toBe(false)
+  })
+
+  it('rejects a .pnp.cjs resolved from within node_modules', () => {
+    expect(
+      isPnpRuntimeWithinNodeModules(
+        abs('app', 'node_modules', 'evil-pkg', '.pnp.cjs'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a nested-node_modules .pnp.cjs', () => {
+    expect(
+      isPnpRuntimeWithinNodeModules(
+        abs('app', 'node_modules', 'a', 'node_modules', 'b', '.pnp.cjs'),
+      ),
+    ).toBe(true)
+  })
+
+  it('does not match a directory whose name merely contains node_modules', () => {
+    expect(
+      isPnpRuntimeWithinNodeModules(abs('app', 'my-node_modules', '.pnp.cjs')),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Two low-risk, self-contained hardening changes to the discovery/notice surfaces. No behavior change for real projects today; both close latent gaps before later trust-lockfile work builds on them.

### 1. Refuse a Yarn PnP runtime resolved from within node_modules
The scanner reads package data as files and never executes discovered package code — with one sanctioned exception: loading the project's own Yarn PnP runtime (`.pnp.cjs`) to map package identities to readable locations. That is safe only for the project's root-or-ancestor manifest.

Today `findPnpFile` walks upward-only, so a `.pnp.cjs` shipped inside a dependency is unreachable — there is no live bug. But nothing *asserts* that: a future change that started the search from a package directory could `require()` a package-supplied `.pnp.cjs` and execute untrusted code in-process.

This adds an explicit, fail-closed guard: if the resolved PnP runtime lives within `node_modules`, `loadPnpApi` throws a clear diagnostic instead of loading it. Exposed as a pure `isPnpRuntimeWithinNodeModules` predicate for direct testing.

### 2. Regression test for the non-suppressible permit-all banner
The `intent.skills: ["*"]` permit-all risk banner must stay visible even under `--no-notices` / `INTENT_NO_NOTICES` (a risk acknowledgment a CI run can mute is not a safeguard). The fix already shipped; this locks it with a test asserting the banner prints through the notices channel under suppression, other notices stay suppressed, and it never leaks into the warnings channel.

## Impact / compatibility
- No observable change for legitimate Yarn PnP projects (their `.pnp.cjs` lives at the project/workspace root, not in `node_modules`).
- The only newly-rejected case is a PnP runtime resolved from inside `node_modules` — precisely the untrusted case, and one the current upward-only search doesn't produce.
- Existing scanner tests (54) unchanged and green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime safety by blocking Yarn Plug’n’Play configurations loaded from within `node_modules`.
  - The app now trusts only project-root or ancestor PnP runtime files, reducing the risk of loading an unintended environment.

- **Tests**
  - Added coverage for the new PnP trust-boundary behavior.
  - Expanded CLI output checks to ensure notices and banners appear in the correct output stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->