### PR TITLE
chore: bust Nx cache for CI timing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,5 @@
 {
+  "bust": 1,
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
   "nxCloudId": "69c71b9038eed5e74d5da8e4",


### PR DESCRIPTION
## Summary

- Adds a temporary Nx config cache-bust marker to force CI work to rerun.
- Keeps the change isolated on a draft PR for CI timing estimation.

## Impact

- **Architecture**: None expected; this only changes repository config metadata.
- **Performance / bundle size**: None expected in product output.
- **Risk**: Low for the timing probe, but this should not be merged as-is unless the cache-bust marker is intentional.
- **User-facing changes**: None expected.

## Testing

- Not run; draft PR is intended to trigger CI for timing estimation.