### PR TITLE
chore: add root test:integration script

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,8 @@ jobs:
           main-branch-name: main
       - name: Run Checks
         run: pnpm run test:pr
+      - name: Run Integration Tests
+        run: pnpm run test:integration
   preview:
     name: Preview
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -37,10 +37,11 @@
     "test:ci": "tsc --noEmit && nx run-many --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:integration,test:types,build",
     "test:docs": "node scripts/verify-links.ts",
     "test:eslint": "nx affected --target=test:eslint --exclude=examples/**",
+    "test:integration": "nx affected --targets=test:integration --exclude=examples/**",
     "test:knip": "knip",
     "test:lib": "nx affected --targets=test:lib --exclude=examples/**",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
-    "test:pr": "tsc --noEmit && nx affected --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:integration,test:types,build",
+    "test:pr": "tsc --noEmit && nx affected --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:types,build",
     "test:sherif": "sherif",
     "test:types": "nx affected --targets=test:types --exclude=examples/**",
     "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:knip": "knip",
     "test:lib": "nx affected --targets=test:lib --exclude=examples/**",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
-    "test:pr": "tsc --noEmit && nx affected --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:types,build",
+    "test:pr": "tsc --noEmit && nx affected --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:integration,test:types,build",
     "test:sherif": "sherif",
     "test:types": "nx affected --targets=test:types --exclude=examples/**",
     "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:ci": "tsc --noEmit && nx run-many --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:integration,test:types,build",
     "test:docs": "node scripts/verify-links.ts",
     "test:eslint": "nx affected --target=test:eslint",
+    "test:integration": "nx affected --targets=test:integration",
     "test:knip": "knip",
     "test:lib": "nx affected --targets=test:lib",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",


### PR DESCRIPTION
Stack (merge in order): #198 → #287 → #288 → #289 → #290 → #259.

Adds the root `test:integration` script (`nx affected --targets=test:integration`), matching the existing `test:lib` and `test:types` entry points. Contributors can run affected integration tests directly from the repository root. The branch includes the current main fixes for CI dependency checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a package script for running affected integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->