### PR TITLE
chore: stabilize consumer foundations and align trust documentation

### DIFF
--- a/.changeset/quiet-sources-rest.md
+++ b/.changeset/quiet-sources-rest.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Remove internal milestone wording from unsupported `git:` source errors.

--- a/docs/cli/intent-hooks.md
+++ b/docs/cli/intent-hooks.md
@@ -3,7 +3,7 @@ title: intent hooks
 id: intent-hooks
 ---
 
-`intent hooks install` installs lifecycle hooks that surface available Intent skills and enforce loading matching guidance before edits in supported agents.
+`intent hooks install` installs lifecycle hooks that surface available Intent skills and gate supported edit tools until they observe an Intent load command.
 
 ```bash
 npx @tanstack/intent@latest hooks install [--scope project|user] [--agents copilot,claude,codex|all]
@@ -17,13 +17,15 @@ npx @tanstack/intent@latest hooks install [--scope project|user] [--agents copil
 ## Behavior
 
 - Installs hook behavior without writing an `intent-skills` guidance block.
-- Adds a session-start skill catalog for supported agents so the agent sees available `skill-id: description` entries before it starts work.
-- Keeps edit enforcement in place: supported edit tools are blocked until the agent runs `intent load <skill-id>` for matching guidance.
+- Returns a session-start skill catalog as agent context with available `skill-id: description` entries.
+- Blocks supported edit tools until the hook observes a recognized `intent load <skill-id>` command.
 - `--scope project` writes project-local hook config for agents that support it.
 - `--scope user` writes user-level agent config and stores runner scripts under `~/.tanstack/intent/hooks`.
 - `--agents all` is the default. In project scope, Copilot is skipped because the supported Copilot CLI hook location is user-scoped.
 - Run `intent install` separately when you also want to write project guidance.
 - Use `package.json#intent.skills` and `package.json#intent.exclude` to control which skills are surfaced in the session catalog.
+
+The hook records a recognized load command before that command completes. It does not verify that the command succeeded, that the selected skill matched the task, that the agent received the returned content, or that the model applied the guidance. Hook output is an edit gate and observation signal, not proof of activation or correct agent behavior. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
 
 ## Hook support
 

--- a/docs/cli/intent-hooks.md
+++ b/docs/cli/intent-hooks.md
@@ -16,16 +16,30 @@ npx @tanstack/intent@latest hooks install [--scope project|user] [--agents copil
 
 ## Behavior
 
+### Session behavior
+
 - Installs hook behavior without writing an `intent-skills` guidance block.
 - Returns a session-start skill catalog as agent context with available `skill-id: description` entries.
 - Blocks supported edit tools until the hook observes a recognized `intent load <skill-id>` command.
+- Uses `package.json#intent.skills` and `package.json#intent.exclude` to control which skills appear in the session catalog.
+
+### Installation behavior
+
 - `--scope project` writes project-local hook config for agents that support it.
 - `--scope user` writes user-level agent config and stores runner scripts under `~/.tanstack/intent/hooks`.
 - `--agents all` is the default. In project scope, Copilot is skipped because the supported Copilot CLI hook location is user-scoped.
 - Run `intent install` separately when you also want to write project guidance.
-- Use `package.json#intent.skills` and `package.json#intent.exclude` to control which skills are surfaced in the session catalog.
 
-The hook records a recognized load command before that command completes. It does not verify that the command succeeded, that the selected skill matched the task, that the agent received the returned content, or that the model applied the guidance. Hook output is an edit gate and observation signal, not proof of activation or correct agent behavior. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
+The hook records a recognized load command before that command completes.
+
+Hooks do not verify that:
+
+- The command succeeded.
+- The selected skill matched the task.
+- The agent received the returned content.
+- The model applied the guidance.
+
+Hook output is an edit gate and observation signal, not proof of activation or correct agent behavior. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
 
 ## Hook support
 

--- a/docs/cli/intent-install.md
+++ b/docs/cli/intent-install.md
@@ -25,15 +25,20 @@ npx @tanstack/intent@latest install [--map] [--dry-run] [--print-prompt] [--glob
 
 ## Behavior
 
+### Default guidance
+
 - Writes lightweight skill loading guidance by default.
 - Creates `AGENTS.md` when no managed block exists.
 - Updates an existing managed block in a supported config file.
 - Preserves all content outside the managed block.
+- Verifies the managed block before reporting success.
+
+### Mapping mode
+
 - Scans packages and writes compact `id`, `run`, and `for` mappings only when `--map` is passed.
 - Surfaces packages permitted by `package.json#intent.skills` in `--map` mode. See [Configuration](../concepts/configuration).
 - Skips reference, meta, maintainer, and maintainer-only skills in `--map` mode.
 - Writes compact skill identities and runnable guidance commands instead of local file paths in `--map` mode.
-- Verifies the managed block before reporting success.
 - Prints `No intent-enabled skills found.` and does not create a config file when `--map` finds no actionable skills.
 
 Supported config files: `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`.
@@ -76,13 +81,15 @@ tanstackIntent:
 
 ## Status messages
 
-- Created: `Created AGENTS.md with 1 mapping.`
-- Updated: `Updated AGENTS.md with 2 mappings.`
-- Unchanged: `No changes to AGENTS.md; 2 mappings already current.`
-- Guidance created: `Created AGENTS.md with skill loading guidance.`
-- Guidance unchanged: `No changes to AGENTS.md; skill loading guidance already current.`
-- Placement tip: `Tip: Keep the intent-skills block near the top of AGENTS.md so agents read it before task-specific instructions.`
-- No actionable skills in `--map` mode: `No intent-enabled skills found.`
+| Result | Message |
+| --- | --- |
+| Mapping created | `Created AGENTS.md with 1 mapping.` |
+| Mappings updated | `Updated AGENTS.md with 2 mappings.` |
+| Mappings unchanged | `No changes to AGENTS.md; 2 mappings already current.` |
+| Guidance created | `Created AGENTS.md with skill loading guidance.` |
+| Guidance unchanged | `No changes to AGENTS.md; skill loading guidance already current.` |
+| Placement tip | `Tip: Keep the intent-skills block near the top of AGENTS.md so agents read it before task-specific instructions.` |
+| No actionable skills in `--map` mode | `No intent-enabled skills found.` |
 
 To suppress trust and migration notices in automation, pass `--no-notices`.
 

--- a/docs/cli/intent-list.md
+++ b/docs/cli/intent-list.md
@@ -16,7 +16,7 @@ npx @tanstack/intent@latest list [--json] [--debug] [--global] [--global-only] [
 - `--global`: include global packages after project packages
 - `--global-only`: list global packages only
 - `--show-hidden`: show unlisted hidden skill sources when run outside an agent session
-- `--no-notices`: suppress non-critical notices on stderr
+- `--no-notices`: suppress non-critical notices on stderr; the acknowledged-risk notice for `intent.skills: ["*"]` remains visible
 
 ## What you get
 
@@ -118,7 +118,7 @@ The list as a whole has three special forms:
 - **Empty** (`"skills": []`): no package is surfaced, with an info notice printed to stderr.
 - **Wildcard** (`"skills": ["*"]`): every discovered package is surfaced, with an acknowledged-risk notice printed to stderr. This exact trust-all entry is distinct from a scoped package pattern such as `@tanstack/*`.
 
-A package that ships skills but is not listed or matched by a pattern is dropped. When packages are dropped this way, Intent prints one summary line naming them so you can opt in. In agent sessions, hidden sources are reported by count only; run `intent list --show-hidden` outside the agent session to review candidates. An exact entry or pattern that matches no discovered package is reported as well. Package patterns support `*` wildcards. Matching is currently by package name. See [Configuration](../concepts/configuration) and [Trust model](../concepts/trust-model).
+A package that ships skills but is not listed or matched by a pattern is dropped. When packages are dropped this way, Intent prints one policy notice naming them so you can opt in. In agent sessions, hidden sources are reported by count only; run `intent list --show-hidden` outside the agent session to review candidates. An exact entry or pattern that matches no discovered package is reported as well. Package patterns support `*` wildcards. Matching uses both package name and source kind. See [Configuration](../concepts/configuration) and [Trust model](../concepts/trust-model).
 
 ## Excludes
 
@@ -136,7 +136,7 @@ Manage persistent excludes with `intent exclude add|remove|list`.
 
 A pattern without `#` excludes a whole package. A pattern with `#` excludes a single skill (`@scope/pkg#search-params`), and the skill segment may itself be a glob (`@scope/pkg#experimental-*`). A pattern may cross package boundaries at skill granularity (`*#experimental-*`). The `#*` shortcut (`@scope/pkg#*`) excludes the whole package. Only exact names and `*` wildcards are supported on each segment. Bare package-name patterns keep working unchanged.
 
-An excluded package never triggers the unlisted-source warning, because an exclude is an explicit decision rather than an oversight.
+An excluded package never triggers the unlisted-source notice, because an exclude is an explicit decision rather than an oversight.
 
 ## Common errors
 

--- a/docs/cli/intent-list.md
+++ b/docs/cli/intent-list.md
@@ -11,30 +11,38 @@ npx @tanstack/intent@latest list [--json] [--debug] [--global] [--global-only] [
 
 ## Options
 
+### Output
+
 - `--json`: print JSON instead of text output
 - `--debug`: print discovery debug details to stderr
+- `--no-notices`: suppress non-critical notices on stderr; the acknowledged-risk notice for `intent.skills: ["*"]` remains visible
+
+### Scan scope
+
 - `--global`: include global packages after project packages
 - `--global-only`: list global packages only
 - `--show-hidden`: show unlisted hidden skill sources when run outside an agent session
-- `--no-notices`: suppress non-critical notices on stderr; the acknowledged-risk notice for `intent.skills: ["*"]` remains visible
 
 ## What you get
+
+### Selection
 
 - Scans project and workspace dependencies for intent-enabled packages and skills
 - Surfaces packages permitted by `package.json#intent.skills` (see [Allowlist](#allowlist))
 - Includes global packages only when `--global` or `--global-only` is passed
-- Includes warnings from discovery
 - Excludes packages and skills matched by package.json `intent.exclude`
-- Prints debug details to stderr when `--debug` is passed
-- If no packages are discovered, prints `No intent-enabled packages found.`
+
+When both local and global packages are scanned, local packages take precedence. `SOURCE` shows whether the selected package came from local discovery or explicit global scanning.
+
+### Text output
+
 - Summary line with package count and skill count
 - Package table columns: `PACKAGE`, `SOURCE`, `VERSION`, `SKILLS`
 - Skill tree grouped by package
-- Optional warnings section (`⚠ ...` per warning)
-- Optional notices section on stderr (`ℹ ...` per notice), suppressed by `--no-notices`
+- Discovery warnings (`⚠ ...`) on stdout
+- `No intent-enabled packages found.` when no packages are discovered
 
-`SOURCE` is a lightweight indicator showing whether the selected package came from local discovery or explicit global scanning.
-When both local and global packages are scanned, local packages take precedence.
+Policy notices (`ℹ ...`) are written to stderr.
 
 ## JSON output
 
@@ -141,5 +149,4 @@ An excluded package never triggers the unlisted-source notice, because an exclud
 ## Common errors
 
 - Scanner failures are printed as errors
-- Unsupported environments:
-  - Deno projects without `node_modules`
+- Deno projects without `node_modules` are unsupported

--- a/docs/cli/intent-load.md
+++ b/docs/cli/intent-load.md
@@ -22,13 +22,15 @@ npx @tanstack/intent@latest load <package>#<skill> [--path] [--json] [--debug] [
 - Validates `<package>#<skill>` before scanning
 - Scans project-local packages by default
 - Includes global packages only when `--global` or `--global-only` is passed
-- Refuses before scanning when the target package is not permitted by `package.json#intent.skills`
+- Checks the target package name against `package.json#intent.skills` before resolution, then enforces its source kind after resolution
 - Refuses before scanning when the target package or skill matches `intent.exclude`
 - Prefers local packages when `--global` is used and the same package exists locally and globally
 - Accepts an unambiguous short skill name when a package-prefixed skill exists
 - Prints raw `SKILL.md` content by default
 - Prints the scanner-reported path when `--path` is passed
 - Prints debug details to stderr when `--debug` is passed
+
+A successful load proves that Intent resolved the selected skill under current policy and returned its content. It does not prove that the skill was relevant to the task, reached an agent's active context, or was followed correctly. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
 
 The package can be scoped or unscoped. The skill can include slash-separated sub-skill names.
 

--- a/docs/cli/intent-load.md
+++ b/docs/cli/intent-load.md
@@ -19,13 +19,21 @@ npx @tanstack/intent@latest load <package>#<skill> [--path] [--json] [--debug] [
 
 ## What you get
 
+### Resolution
+
 - Validates `<package>#<skill>` before scanning
 - Scans project-local packages by default
 - Includes global packages only when `--global` or `--global-only` is passed
 - Checks the target package name against `package.json#intent.skills` before resolution, then enforces its source kind after resolution
 - Refuses before scanning when the target package or skill matches `intent.exclude`
+
+### Selection
+
 - Prefers local packages when `--global` is used and the same package exists locally and globally
 - Accepts an unambiguous short skill name when a package-prefixed skill exists
+
+### Output
+
 - Prints raw `SKILL.md` content by default
 - Prints the scanner-reported path when `--path` is passed
 - Prints debug details to stderr when `--debug` is passed
@@ -62,12 +70,20 @@ npx @tanstack/intent@latest load some-lib#core --path
 
 ## Common errors
 
+### Invalid skill identity
+
 - Missing separator: `Invalid skill use "@tanstack/query": expected <package>#<skill>.`
 - Empty package: `Invalid skill use "#core": package is required.`
 - Empty skill: `Invalid skill use "@tanstack/query#": skill is required.`
+
+### Resolution failures
+
 - Missing package: `Cannot resolve skill use "...": package "..." was not found.`
 - Missing skill: `Cannot resolve skill use "...": skill "..." was not found in package "...".`
 - Skill suggestion: `Did you mean @tanstack/router-core#router-core/auth-and-guards?`
+
+### Policy refusals
+
 - Unlisted package: `Cannot load skill use "...": package "..." is not listed in intent.skills.`
 - Excluded package: `Cannot load skill use "...": package "..." is excluded by Intent configuration.`
 - Excluded skill: `Cannot load skill use "...": skill "..." is excluded by Intent configuration.`

--- a/docs/cli/intent-setup.md
+++ b/docs/cli/intent-setup.md
@@ -18,16 +18,19 @@ npx @tanstack/intent@latest setup
 
 ## What each command changes
 
-- `edit-package-json`
-  - Requires a valid `package.json` in current directory
-  - Ensures `keywords` includes `tanstack-intent`
-  - Ensures `files` includes required publish entries
-  - Preserves existing indentation
-- `setup`
-  - Copies the `check-skills.yml` workflow template from `@tanstack/intent/meta/templates/workflows` to `.github/workflows`
-  - Applies variable substitution (`PACKAGE_NAME`, `PACKAGE_LABEL`, `PAYLOAD_PACKAGE`, `REPO`, `DOCS_PATH`, `SRC_PATH`, `WATCH_PATHS`)
-  - Detects the workspace root in monorepos and writes repo-level workflows there
-  - Skips files that already exist at destination
+### `edit-package-json`
+
+- Requires a valid `package.json` in the current directory
+- Ensures `keywords` includes `tanstack-intent`
+- Ensures `files` includes required publish entries
+- Preserves existing indentation
+
+### `setup`
+
+- Copies the `check-skills.yml` workflow template from `@tanstack/intent/meta/templates/workflows` to `.github/workflows`
+- Applies variable substitution (`PACKAGE_NAME`, `PACKAGE_LABEL`, `PAYLOAD_PACKAGE`, `REPO`, `DOCS_PATH`, `SRC_PATH`, `WATCH_PATHS`)
+- Detects the workspace root in monorepos and writes repo-level workflows there
+- Skips files that already exist at the destination
 
 ## Required `files` entries
 

--- a/docs/cli/intent-stale.md
+++ b/docs/cli/intent-stale.md
@@ -15,14 +15,22 @@ npx @tanstack/intent@latest stale [--json]
 
 ## Behavior
 
+### Scope
+
 - Checks the current package by default
 - From a monorepo root, checks workspace packages that ship skills and also reports public workspace packages with no skill or artifact coverage
 - Applies the `package.json#intent.skills` allowlist when falling back to installed dependencies; workspace packages are first-party and checked regardless. See [Configuration](../concepts/configuration).
 - When `dir` is provided, scopes the check to the targeted package or skills directory
 - Computes one staleness report per package
+
+### Coverage
+
 - Reads repo-root `_artifacts/*domain_map.yaml` and `_artifacts/*skill_tree.yaml` when present
 - Flags public workspace packages that are not represented by generated skills or artifact coverage
 - Skips workspace packages with `"private": true`
+
+### Output and workflow state
+
 - Prints text output by default or JSON with `--json`
 - Prints a non-failing workflow update reminder when `.github/workflows/check-skills.yml` is missing the current `intent-workflow-version` stamp
 - If no packages are found, prints `No intent-enabled packages found.`
@@ -74,12 +82,14 @@ Ignored packages are excluded from missing coverage signals. Private workspace p
 
 Report fields:
 
-- `library`: package name
-- `currentVersion`: latest version from npm registry (or `null` if unavailable)
-- `skillVersion`: `library_version` from skills (or `null`)
-- `versionDrift`: `major | minor | patch | null`
-- `skills`: array of per-skill checks
-- `signals`: array of artifact and workspace coverage checks
+| Field | Meaning |
+| --- | --- |
+| `library` | Package name |
+| `currentVersion` | Latest version from npm registry, or `null` if unavailable |
+| `skillVersion` | `library_version` from skills, or `null` |
+| `versionDrift` | `major`, `minor`, `patch`, or `null` |
+| `skills` | Per-skill checks |
+| `signals` | Artifact and workspace coverage checks |
 
 Skill fields:
 

--- a/docs/cli/intent-validate.md
+++ b/docs/cli/intent-validate.md
@@ -49,21 +49,25 @@ npx @tanstack/intent@latest validate --fix
 
 ## Validation checks
 
-For each discovered `SKILL.md`:
+### File structure
 
 - Frontmatter delimiter and structure are valid
 - YAML frontmatter parses successfully
 - Required fields exist: `name`, `description`
 - `name` is a single leaf segment matching the skill's parent directory (no slashes); the namespace is carried by the directory path
-- `name` uses only lowercase letters, numbers, and hyphens
-- `name` is at most 64 characters
+- `name` uses only lowercase letters, numbers, and hyphens and is at most 64 characters
+
+### Field rules
+
 - Only spec top-level keys are allowed (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`); Intent-specific scalars (`type`, `library`, `library_version`, `framework`) must live under `metadata`
 - `metadata`, when present, is a mapping of string values
 - `description` length is at most 1024 characters
 - `type: framework` requires `requires` to be an array
 - Total file length is at most 500 lines
 
-If `<dir>/_artifacts` exists, it also validates artifacts:
+### Artifacts
+
+When `<dir>/_artifacts` exists, Intent also checks:
 
 - Required files: `domain_map.yaml`, `skill_spec.md`, `skill_tree.yaml`
 - Required files must be non-empty

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 id: configuration
 ---
 
-Intent reads consumer configuration from the `intent` object in `package.json`. Two keys control which skills reach your agent: `skills` (the allowlist) and `exclude` (the blocklist).
+Intent reads consumer configuration from the `intent` object in `package.json`. Two keys control which discovered skills Intent surfaces: `skills` (the allowlist) and `exclude` (the blocklist).
 
 ```json
 {
@@ -14,11 +14,13 @@ Intent reads consumer configuration from the `intent` object in `package.json`. 
 }
 ```
 
-Intent merges these keys from every `package.json` between the current working directory and the workspace or project root. A monorepo package inherits the root configuration and adds its own.
+Intent resolves `skills` from the nearest `package.json` between the current working directory and the workspace or project root that declares a non-null value. A nearer declaration replaces a parent declaration; an omitted or null value inherits the nearest parent declaration. Intent combines `exclude` arrays from the root through the current working directory, then adds excludes passed by the caller.
 
 ## `intent.skills`
 
-`intent.skills` is the allowlist. Only packages it permits contribute skills to `list`, `load`, `install`, and `stale`. See [Trust model](./trust-model) for the reasoning.
+`intent.skills` is a package-source allowlist. Permitted packages surface in `list` and `stale`, can resolve through `load`, and contribute mappings to `install --map`. The default `install` command writes generic loading guidance without scanning packages. See [Trust model](./trust-model) for the reasoning and lifecycle boundaries.
+
+The allowlist permits packages, not individual skills. An entry containing `#` is invalid; use `intent.exclude` for skill-specific filtering.
 
 ### Source entries
 
@@ -26,12 +28,13 @@ Each array entry names one source:
 
 | Entry | Kind | Meaning |
 | ----- | ---- | ------- |
-| `@scope/pkg` or `pkg` | npm | A package reachable through the dependency tree, direct or transitive. |
+| `@scope/pkg` or `pkg` | npm | An npm package reachable through the dependency tree, direct or transitive. |
 | `workspace:@scope/pkg` | workspace | A package in the current workspace. |
-| `@scope/*` or `workspace:@scope/*` | npm or workspace | Every discovered package of that kind whose name matches the pattern. |
+| `@scope/*` | npm | Every discovered npm package whose name matches the pattern. |
+| `workspace:@scope/*` | workspace | Every discovered workspace package whose name matches the pattern. |
 | `git:<host>/<repo>#<ref>` | git | Reserved. Not yet supported, and rejected until a future version adds it. |
 
-A malformed entry fails the whole command, and every bad entry is reported at once. Package patterns support `*` wildcards, including scoped patterns such as `@tanstack/*`. Intent matches allowlist entries against discovered package names. This matching will tighten in a future version.
+A malformed entry fails the whole command, and every bad entry is reported at once. Package patterns support `*` wildcards, including scoped patterns such as `@tanstack/*`. Intent matches both the package name and source kind: a bare entry permits only an npm source, and a `workspace:` entry permits only a workspace source.
 
 ### Special forms
 
@@ -41,7 +44,7 @@ The list as a whole has three special forms:
 - **Empty.** `"skills": []`. No package is surfaced. Intent prints an info notice to stderr.
 - **Wildcard.** `"skills": ["*"]`. Every discovered package is surfaced. Unlike a package pattern such as `@tanstack/*`, this exact entry crosses package scopes and source kinds. Intent prints an acknowledged-risk notice to stderr, since unvetted skills may reach your agent.
 
-A package that ships skills but is not listed is dropped. When packages are dropped this way, Intent prints one summary line naming them so you can opt in. A listed package that was not discovered is reported as well.
+A package that ships skills but is not listed is dropped. In human output, Intent adds one policy notice naming packages dropped this way so you can opt in. Agent sessions receive only the hidden package and skill counts. A listed package that was not discovered is reported as a notice as well.
 
 ### Existing projects
 
@@ -57,6 +60,8 @@ npx @tanstack/intent@latest install --map --no-notices
 ```
 
 For CI or wrapper scripts, set `INTENT_NO_NOTICES=1` to suppress notices without changing command arguments.
+
+Discovery and resolution warnings are separate from policy notices and are not suppressed by these options. The acknowledged-risk notice for `"skills": ["*"]` also remains visible when other notices are suppressed.
 
 ## `intent.exclude`
 
@@ -86,4 +91,4 @@ Pattern grammar:
 - A pattern may cross package boundaries at skill granularity: `*#experimental-*`.
 - The `#*` shortcut excludes the whole package: `@scope/pkg#*`.
 
-Only exact names and `*` wildcards are supported on each segment. Bare package-name patterns keep working unchanged. An excluded package does not trigger the unlisted-source warning, because an exclude is an explicit decision.
+Only exact names and `*` wildcards are supported on each segment. Excludes are source-kind agnostic, so a package pattern excludes matching npm and workspace sources. An excluded package does not trigger the unlisted-source notice, because an exclude is an explicit decision.

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -14,11 +14,20 @@ Intent reads consumer configuration from the `intent` object in `package.json`. 
 }
 ```
 
-Intent resolves `skills` from the nearest `package.json` between the current working directory and the workspace or project root that declares a non-null value. A nearer declaration replaces a parent declaration; an omitted or null value inherits the nearest parent declaration. Intent combines `exclude` arrays from the root through the current working directory, then adds excludes passed by the caller.
+## Configuration inheritance
+
+- **`intent.skills`:** Intent uses the nearest non-null declaration between the current working directory and the workspace or project root. A nearer declaration replaces its parent. An omitted or null value inherits the nearest parent declaration.
+- **`intent.exclude`:** Intent combines arrays from the root through the current working directory, then adds excludes passed by the caller.
 
 ## `intent.skills`
 
-`intent.skills` is a package-source allowlist. Permitted packages surface in `list` and `stale`, can resolve through `load`, and contribute mappings to `install --map`. The default `install` command writes generic loading guidance without scanning packages. See [Trust model](./trust-model) for the reasoning and lifecycle boundaries.
+`intent.skills` is a package-source allowlist. A permitted package can:
+
+- Appear in `list` and `stale`.
+- Resolve through `load`.
+- Contribute mappings to `install --map`.
+
+The default `install` command writes generic loading guidance without scanning packages. See [Trust model](./trust-model) for the reasoning and lifecycle boundaries.
 
 The allowlist permits packages, not individual skills. An entry containing `#` is invalid; use `intent.exclude` for skill-specific filtering.
 
@@ -38,17 +47,19 @@ A malformed entry fails the whole command, and every bad entry is reported at on
 
 ### Special forms
 
-The list as a whole has three special forms:
-
-- **Absent.** No `intent.skills` key. Every discovered package is surfaced, and Intent prints a deprecation notice to stderr on each run until you set `intent.skills`. This is the upgrade path for existing projects. A future version will require an explicit allowlist.
-- **Empty.** `"skills": []`. No package is surfaced. Intent prints an info notice to stderr.
-- **Wildcard.** `"skills": ["*"]`. Every discovered package is surfaced. Unlike a package pattern such as `@tanstack/*`, this exact entry crosses package scopes and source kinds. Intent prints an acknowledged-risk notice to stderr, since unvetted skills may reach your agent.
+| Form | Result | Notice |
+| --- | --- | --- |
+| **Absent:** no `intent.skills` key | Surfaces every discovered package as an upgrade path for existing projects. A future version will require an explicit allowlist. | Deprecation notice on stderr on each run until you set `intent.skills`. |
+| **Empty:** `"skills": []` | Surfaces no packages. | Info notice on stderr. |
+| **Wildcard:** `"skills": ["*"]` | Surfaces every discovered package across package scopes and source kinds. This is broader than a pattern such as `@tanstack/*`. | Acknowledged-risk notice on stderr because unvetted skills may reach your agent. |
 
 A package that ships skills but is not listed is dropped. In human output, Intent adds one policy notice naming packages dropped this way so you can opt in. Agent sessions receive only the hidden package and skill counts. A listed package that was not discovered is reported as a notice as well.
 
 ### Existing projects
 
-A project that has not set `intent.skills` keeps working. Intent surfaces every discovered package and prints the deprecation notice described under the absent form. Nothing breaks. Add an allowlist when you are ready, before a future version requires one. Run `intent list` to confirm which packages are surfaced.
+Run `intent list` to see which packages the current policy surfaces.
+
+A project without `intent.skills` uses the absent form: Intent surfaces every discovered package and prints its deprecation notice. Add an allowlist to permit specific sources before a future version requires one.
 
 ### Suppressing notices temporarily
 

--- a/docs/concepts/trust-model.md
+++ b/docs/concepts/trust-model.md
@@ -23,16 +23,18 @@ One exception is sanctioned: in Yarn Plug'n'Play projects, Intent loads Yarn's P
 
 ## Lifecycle boundaries
 
-Intent uses these states as separate boundaries:
+Intent uses six lifecycle stages in order. It can observe the first three and its side of delivery. Activation and application depend on agent behavior.
 
-1. **Available.** Intent discovered the skill from an installed or workspace package.
-2. **Permitted.** Project policy allows the package and skill to surface. `intent.exclude` can remove a package or skill after `intent.skills` permits its source.
-3. **Loaded.** A supported load path resolved the skill and returned its content.
-4. **Delivered.** Intent placed guidance where an agent integration can access it, such as a managed guidance block or session hook context.
-5. **Activated.** The agent selected or received the skill for a particular task.
-6. **Applied.** The model followed the skill correctly.
+| State | Meaning | Observable by Intent |
+| --- | --- | --- |
+| **1. Available** | Intent discovered the skill from an installed or workspace package. | Yes. |
+| **2. Permitted** | Project policy allows the package and skill to surface. `intent.exclude` can remove a package or skill after `intent.skills` permits its source. | Yes. |
+| **3. Loaded** | A supported load path resolved the skill and returned its content. | Yes. |
+| **4. Delivered** | Intent placed guidance where an agent integration can access it, such as a managed guidance block or session hook context. | Intent can confirm its output, not agent receipt. |
+| **5. Activated** | The agent selected or received the skill for a particular task. | No. |
+| **6. Applied** | The model followed the skill correctly. | No. |
 
-Intent can report discovery and policy results, confirm a successful `intent load`, verify a managed block it writes, and emit hook context. Those observations cover Available, Permitted, Loaded, and Intent's side of Delivered. Activated and Applied depend on agent behavior and are not states Intent can prove. A hook observing an `intent load` command does not prove that the command succeeded, that the skill was relevant, or that the model used its guidance.
+A hook observing an `intent load` command does not prove that the command succeeded, that the skill was relevant, or that the model used its guidance.
 
 ## Unsupported sources
 

--- a/docs/concepts/trust-model.md
+++ b/docs/concepts/trust-model.md
@@ -3,17 +3,17 @@ title: Trust model
 id: trust-model
 ---
 
-Intent surfaces skills from your dependencies into your coding agent's guidance. A skill is instructions an agent follows, so the set of packages allowed to contribute skills is a trust decision. Intent makes that decision explicit through the `intent.skills` allowlist.
+Intent discovers skills from your dependencies and can surface permitted skills through its CLI and agent integrations. A skill is instructions an agent follows, so the set of packages allowed to contribute skills is a trust decision. Intent makes that decision explicit through the `intent.skills` allowlist.
 
 ## Explicit sources
 
 A package ships skills in a `skills/` directory. Discovery finds every installed package that has one, including transitive dependencies. Discovery does not grant trust.
 
-`package.json#intent.skills` is the gate. A discovered package contributes skills only when an exact entry or `*` pattern in the allowlist matches it. An unlisted package is dropped, and Intent reports it so you can opt in or ignore it.
+`package.json#intent.skills` is the gate. A discovered package contributes skills only when an exact entry or `*` pattern in the allowlist matches its package name and source kind. An unlisted package is dropped, and Intent reports it so you can opt in or ignore it.
 
 The gate is opt-in today. A project with no `intent.skills` key still surfaces every discovered package, and Intent prints a deprecation notice to stderr on each run until you set `intent.skills`. A future version will require an explicit allowlist. See the [special forms](./configuration#special-forms) in Configuration.
 
-Trust does not propagate. A listed package may depend on another package that ships skills, but that dependency stays unlisted unless another entry matches it. Exact entries allow one source; patterns such as `@tanstack/*` explicitly allow every matching source.
+Trust does not propagate. A listed package may depend on another package that ships skills, but that dependency stays unlisted unless another entry matches it. A bare entry such as `foo` permits an npm source, while `workspace:foo` permits a workspace source. Their wildcard forms remain kind-specific. The exact `*` entry permits every discovered npm and workspace source.
 
 ## Static discovery
 
@@ -21,8 +21,19 @@ Intent reads package data as files. It never imports, requires, or executes the 
 
 One exception is sanctioned: in Yarn Plug'n'Play projects, Intent loads Yarn's PnP runtime (`.pnp.cjs`) to map package identities to readable locations. It loads no package entry points, bins, lifecycle scripts, or other package-provided JavaScript. An ESLint rule enforces this invariant in the discovery code.
 
-## What the allowlist does not cover yet
+## Lifecycle boundaries
 
-Matching is currently by package name. A `workspace:foo` entry and a bare `foo` entry both authorize a discovered package named `foo`, because the scanner does not yet distinguish a workspace member from a published package of the same name. This errs toward permitting a same-named package, never toward denying one you listed. A future version tightens matching once the scanner carries that signal.
+Intent uses these states as separate boundaries:
+
+1. **Available.** Intent discovered the skill from an installed or workspace package.
+2. **Permitted.** Project policy allows the package and skill to surface. `intent.exclude` can remove a package or skill after `intent.skills` permits its source.
+3. **Loaded.** A supported load path resolved the skill and returned its content.
+4. **Delivered.** Intent placed guidance where an agent integration can access it, such as a managed guidance block or session hook context.
+5. **Activated.** The agent selected or received the skill for a particular task.
+6. **Applied.** The model followed the skill correctly.
+
+Intent can report discovery and policy results, confirm a successful `intent load`, verify a managed block it writes, and emit hook context. Those observations cover Available, Permitted, Loaded, and Intent's side of Delivered. Activated and Applied depend on agent behavior and are not states Intent can prove. A hook observing an `intent load` command does not prove that the command succeeded, that the skill was relevant, or that the model used its guidance.
+
+## Unsupported sources
 
 The `git:` source kind is reserved. Intent parses and validates the shape, then rejects it until a future version can pin the resolved ref and content hash. A git entry never loads silently.

--- a/docs/getting-started/quick-start-consumers.md
+++ b/docs/getting-started/quick-start-consumers.md
@@ -56,7 +56,7 @@ npx @tanstack/intent@latest hooks install --scope user --agents copilot
 
 Cursor and generic `AGENTS.md` agents use the guidance block only.
 
-Hooks add the available Intent skill catalog to supported agent sessions and keep the edit gate active until the agent loads matching full guidance. To tailor what appears in the session catalog, configure `intent.skills` and `intent.exclude` in `package.json`.
+Hooks return the available Intent skill catalog as context for supported agent sessions and keep the edit gate active until they observe a supported `intent load` command. They do not verify that the command succeeded, that the skill matched the task, or that the agent applied its guidance. To tailor what appears in the session catalog, configure `intent.skills` and `intent.exclude` in `package.json`.
 
 ## 2. Choose which packages' skills to use
 
@@ -74,7 +74,7 @@ List the packages or `*` package patterns you trust. Intent then surfaces skills
 
 ## 3. Use skills in your workflow
 
-When your agent works on a task that matches an available skill, it loads the matching `SKILL.md` into context.
+The installed guidance tells your agent to select and load a skill when it matches the task. Intent can return the selected `SKILL.md`, but it cannot guarantee that an agent selected the correct skill or followed its guidance. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
 
 Load a skill manually:
 

--- a/docs/getting-started/quick-start-consumers.md
+++ b/docs/getting-started/quick-start-consumers.md
@@ -3,19 +3,17 @@ title: Quick Start for Consumers
 id: quick-start-consumers
 ---
 
-Get started using Intent to help your agent discover and load package skills.
-
 ## 1. Run install
-
-The install command guides your agent through the setup process:
 
 ```bash
 npx @tanstack/intent@latest install
 ```
 
+This command creates or updates skill-loading guidance for your agent.
+
 Examples use `npx` for npm projects. In pnpm, Yarn, or Bun projects, use the matching runner: `pnpm dlx`, `yarn dlx`, or `bunx`.
 
-This creates or updates an `intent-skills` guidance block. It:
+The command:
 
 1. Checks for existing `intent-skills` guidance in your config files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, etc.)
 2. Writes lightweight instructions for skill discovery and loading
@@ -56,7 +54,15 @@ npx @tanstack/intent@latest hooks install --scope user --agents copilot
 
 Cursor and generic `AGENTS.md` agents use the guidance block only.
 
-Hooks return the available Intent skill catalog as context for supported agent sessions and keep the edit gate active until they observe a supported `intent load` command. They do not verify that the command succeeded, that the skill matched the task, or that the agent applied its guidance. To tailor what appears in the session catalog, configure `intent.skills` and `intent.exclude` in `package.json`.
+Hooks return the available Intent skill catalog as context for supported agent sessions and keep the edit gate active until they observe a supported `intent load` command.
+
+Hooks do not verify that:
+
+- The command succeeded.
+- The skill matched the task.
+- The agent applied the guidance.
+
+To control what appears in the session catalog, configure `intent.skills` and `intent.exclude` in `package.json`.
 
 ## 2. Choose which packages' skills to use
 
@@ -74,15 +80,15 @@ List the packages or `*` package patterns you trust. Intent then surfaces skills
 
 ## 3. Use skills in your workflow
 
-The installed guidance tells your agent to select and load a skill when it matches the task. Intent can return the selected `SKILL.md`, but it cannot guarantee that an agent selected the correct skill or followed its guidance. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
-
-Load a skill manually:
+Load a skill when it matches the task:
 
 ```bash
 npx @tanstack/intent@latest load @tanstack/react-query#core
 ```
 
 This prints the skill content for the installed package version.
+
+Intent cannot guarantee that an agent selected the correct skill or followed its guidance. See [Lifecycle boundaries](../concepts/trust-model#lifecycle-boundaries).
 
 If you want explicit task-to-skill mappings in your agent config, opt in:
 
@@ -92,15 +98,13 @@ npx @tanstack/intent@latest install --map
 
 ## 4. Keep skills up-to-date
 
-Skills version with library releases. When you update a library:
-
 ```bash
 npm update @tanstack/react-query
 ```
 
-The new version brings updated skills automatically. The skills are shipped with the library, so you get the version that matches your installed code. If a package is installed both locally and globally and global scanning is enabled, Intent prefers the local version.
+Skills version with library releases. Updating a library also updates its packaged skills, so the skill version matches the installed code. If a package is installed both locally and globally and global scanning is enabled, Intent prefers the local version.
 
-If you need to see what skills have changed, run:
+List the installed skills:
 
 ```bash
 npx @tanstack/intent@latest list

--- a/docs/getting-started/quick-start-maintainers.md
+++ b/docs/getting-started/quick-start-maintainers.md
@@ -52,7 +52,7 @@ This prints a comprehensive prompt that walks you and your agent through three p
 - Validates against the Intent specification
 
 > [!NOTE]
-> This is a context-heavy process that involves domain discovery, GitHub issues analysis, and interactive maintainer interviews. The agent will scan your documentation, recent issues and discussions, and ask targeted questions to surface implicit knowledge and common failure modes. The more information you provide about your library's patterns, pitfalls, and real-world usage problems, the better the generated skills will be. Expect multiple rounds of refinement and regular context compaction before completion.
+> Plan for multiple review rounds and regular context compaction. The agent scans documentation, recent issues, and discussions, then asks targeted questions about implicit knowledge and common failure modes. Provide concrete patterns, pitfalls, and real-world usage problems to improve the generated skills.
 
 ### 2. Validate skills
 
@@ -62,17 +62,19 @@ After scaffolding, validate that all SKILL.md files are well-formed:
 npx @tanstack/intent@latest validate
 ```
 
-This checks:
+This checks skill structure:
+
 - Valid YAML frontmatter in every SKILL.md
 - Required fields (`name`, `description`) are present
 - Skill `name` is a leaf segment matching its parent directory
-- Intent-specific scalars (`type`, `library`, `library_version`, `framework`) live under `metadata`, not at the top level
 - Description length <= 1024 characters
 - Line count limits (500 lines max per skill)
-- Framework skills have a `requires` array
-- Artifact files exist and are non-empty
 
-If any artifacts are present (domain_map.yaml, skill_spec.md, skill_tree.yaml), they must parse as valid YAML.
+It also checks Intent metadata and artifacts:
+
+- Intent-specific scalars (`type`, `library`, `library_version`, `framework`) live under `metadata`, not at the top level
+- Framework skills have a `requires` array
+- Required artifact files exist and are non-empty; YAML artifacts parse successfully
 
 ### 3. Commit skills and artifacts
 
@@ -131,8 +133,8 @@ Consumers who install your library automatically get the skills. They discover l
 
 **Version alignment:**
 - Skills version with your library releases
-- Agents always load the skill matching the installed library version
-- No drift between code and guidance
+- `intent load` returns skill content from the installed package version
+- Packaging code and skills together keeps their versions aligned
 
 ---
 
@@ -143,9 +145,15 @@ Consumers who install your library automatically get the skills. They discover l
 After running `setup`, you'll have `check-skills.yml` in `.github/workflows/`:
 
 **check-skills.yml** (runs on PRs touching skills/artifacts, release, or manual trigger)
+
+Validation:
+
 - Validates SKILL.md frontmatter and structure
 - Ensures files stay under 500 lines
 - Automatically detects stale skills and coverage gaps after you publish a new release
+
+Review handoff:
+
 - Opens one grouped review PR with an agent-friendly prompt
 - Includes the reason each skill or package was flagged
 - Requires you to copy the prompt into Claude Code, Cursor, or your agent to update skills
@@ -180,11 +188,15 @@ coverage:
 
 Private workspace packages are skipped automatically.
 
-**To update stale skills:**
+**Prepare the update:**
+
 1. Review the PR opened by `check-skills.yml`
 2. Copy the agent prompt from the PR description
 3. Paste it into Claude Code, Cursor, or your coding agent
 4. The agent reads the stale skills and updates them based on library changes
+
+**Finish the update:**
+
 5. Run `npx @tanstack/intent@latest validate` locally to verify
 6. Commit and merge the PR
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ id: overview
 
 `@tanstack/intent` is a CLI for shipping and consuming Agent Skills as package artifacts.
 
-Skills are markdown documents that teach AI coding agents how to use your library correctly. Intent versions them with your releases and ships them inside npm packages. It discovers skills from your project and workspace dependencies, then helps agents load them when working on matching tasks.
+Skills are markdown documents that teach AI coding agents how to use your library correctly. Intent versions them with your releases and ships them inside npm packages. It discovers skills from project and workspace dependencies, then provides commands and guidance for loading them.
 
 ## What Intent does
 
@@ -16,21 +16,21 @@ Intent provides tooling for two workflows:
 - Discover skills from your project and workspace dependencies
 - Control which packages' skills are surfaced with an allowlist
 - Add lightweight skill loading guidance to your agent config
-- Add hook enforcement for agents that support blocking lifecycle hooks
-- Keep skills synchronized with library versions
+- Add session catalogs and edit gates for supported agents
+- Use skills packaged with installed library versions
 
 **For maintainers (library teams):**
 
 - Scaffold skills through AI-assisted domain discovery
 - Validate SKILL.md format and packaging
 - Ship skills in the same release pipeline as code
-- Track staleness when source docs change
+- Review version, source, artifact, and package coverage signals
 
 ## How it works
 
 ### Discovery and installation
 
-Examples use `npx` for npm projects. In pnpm, Yarn, or Bun projects, use the matching runner:
+Use the runner for your package manager:
 
 | Tool | Pattern                                      |
 | ---- | -------------------------------------------- |
@@ -57,7 +57,7 @@ Creates or updates lightweight `intent-skills` guidance in your config files (`A
 npx @tanstack/intent@latest hooks install
 ```
 
-Installs hook enforcement for supported agents. Project-scoped hooks are available for Claude Code and Codex. GitHub Copilot CLI project guidance can live in `.github/copilot-instructions.md`, while blocking hooks are user-scoped. Cursor and generic `AGENTS.md` agents use guidance only.
+Installs session catalogs and edit gates for supported agents. Project-scoped hooks are available for Claude Code and Codex. GitHub Copilot CLI project guidance can live in `.github/copilot-instructions.md`, while blocking hooks are user-scoped. Cursor and generic `AGENTS.md` agents use guidance only. See [intent hooks](./cli/intent-hooks) for what hooks can observe.
 
 ```bash
 npx @tanstack/intent@latest load @tanstack/query#fetching
@@ -85,4 +85,4 @@ Enforces SKILL.md format rules and packaging requirements before publish.
 npx @tanstack/intent@latest stale
 ```
 
-Detects when skills reference outdated source documentation or library versions.
+Reports version drift and source, artifact, or package coverage signals that may require skill review.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "build": "nx affected --skip-nx-cache --targets=build --exclude=examples/**",
     "build:all": "nx run-many --targets=build --exclude=examples/**",
-    "build:core": "nx run-many --targets=build --projects=packages/agents",
     "changeset": "changeset",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm format",
@@ -40,7 +39,7 @@
     "test:knip": "knip",
     "test:lib": "nx affected --targets=test:lib --exclude=examples/**",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
-    "test:pr": "tsc --noEmit && nx affected --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:types,build",
+    "test:pr": "tsc --noEmit && nx affected --targets=test:eslint,test:sherif,test:knip,test:docs,test:lib,test:integration,test:types,build",
     "test:sherif": "sherif",
     "test:types": "nx affected --targets=test:types --exclude=examples/**",
     "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all"

--- a/packages/intent/src/core/skill-sources.ts
+++ b/packages/intent/src/core/skill-sources.ts
@@ -1,12 +1,6 @@
 // Static-discovery invariant: this module only inspects strings. It never
 // resolves, requires, or executes any discovered package.
 
-/**
- * Exact entries keep the `kind` + `id` identity M2's lockfile reuses. Patterns
- * select multiple discovered identities and remain distinct from exact entries.
- * The `git` variant is never constructed in M1 (git entries are rejected at
- * parse time) but is defined here so M2 builds on this shape.
- */
 type SkillSource =
   | ({ raw: string; kind: 'npm' | 'workspace' } & (
       { id: string } | { pattern: string }
@@ -172,7 +166,7 @@ function parseEntry(
     case 'git':
       return {
         raw,
-        message: `Git source "${trimmed}" is not supported until the lockfile lands (M2).`,
+        message: `Git source "${trimmed}" is not supported.`,
       }
     default:
       return {

--- a/packages/intent/src/shared/utils.ts
+++ b/packages/intent/src/shared/utils.ts
@@ -153,7 +153,7 @@ export function getDeps(
   for (const field of fields) {
     const d = pkgJson[field]
     if (d && typeof d === 'object') {
-      for (const name of Object.keys(d as Record<string, string>)) {
+      for (const name of Object.keys(d)) {
         deps.add(name)
       }
     }

--- a/packages/intent/tests/integration/source-policy-surfaces.test.ts
+++ b/packages/intent/tests/integration/source-policy-surfaces.test.ts
@@ -73,7 +73,7 @@ describe('source policy — all four surfaces filter excluded and unlisted', () 
   it('list surfaces only the listed package', () => {
     writeStandaloneFixture()
 
-    const result = listIntentSkills({ cwd: root })
+    const result = listIntentSkills({ audience: 'human', cwd: root })
 
     expect(result.packages.map((pkg) => pkg.name)).toEqual([LISTED])
     expect(result.notices.some((notice) => notice.includes(UNLISTED))).toBe(

--- a/packages/intent/tests/skill-sources.test.ts
+++ b/packages/intent/tests/skill-sources.test.ts
@@ -103,8 +103,9 @@ describe('parseSkillSources — malformed entries (fail-whole-list)', () => {
     expect(error.issues).toHaveLength(1)
     expect(error.issues[0]).toMatchObject({
       raw: 'git:github.com/me/skills#main',
+      message:
+        'Git source "git:github.com/me/skills#main" is not supported.',
     })
-    expect(error.issues[0]?.message).toContain('not supported until')
   })
 
   it('rejects an unknown prefix', () => {
@@ -279,7 +280,9 @@ describe('parseSkillSources — error reporting', () => {
       'git:github.com/me/skills#main',
     ])
     expect(error.issues).toHaveLength(2)
-    expect(error.issues[0]?.message).toContain('not supported until')
+    expect(error.issues[0]?.message).toBe(
+      'Git source "git:github.com/me/skills#main" is not supported.',
+    )
     expect(error.issues[1]?.message).toBe('Duplicate entry.')
   })
 

--- a/packages/intent/tests/skill-sources.test.ts
+++ b/packages/intent/tests/skill-sources.test.ts
@@ -103,8 +103,7 @@ describe('parseSkillSources — malformed entries (fail-whole-list)', () => {
     expect(error.issues).toHaveLength(1)
     expect(error.issues[0]).toMatchObject({
       raw: 'git:github.com/me/skills#main',
-      message:
-        'Git source "git:github.com/me/skills#main" is not supported.',
+      message: 'Git source "git:github.com/me/skills#main" is not supported.',
     })
   })
 

--- a/packages/intent/tests/staleness.test.ts
+++ b/packages/intent/tests/staleness.test.ts
@@ -73,11 +73,11 @@ function mockFetchVersion(version: string): void {
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: () => Promise.resolve({ version }),
-  } as Response)
+  })
 }
 
 function mockFetchNotOk(): void {
-  globalThis.fetch = vi.fn().mockResolvedValue({ ok: false } as Response)
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: false })
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Prepare the current consumer foundation for later accepted-state and delivery work by running the existing integration suite in PR validation, removing stale repository and milestone references, fixing deterministic integration-test output, and aligning trust documentation with shipped behavior.

## Why

The PR workflow ran unit, type, lint, docs, and build targets but omitted the existing package-manager, filesystem, PnP, load, scanner, and source-policy integration suite. The docs also described merged `intent.skills`, name-only source matching, and stronger hook and agent guarantees than the current implementation provides. Correcting this base first keeps later product PRs focused and reviewable.

## Changes

- Add the existing `test:integration` Nx target to `pnpm run test:pr`.
- Remove the unused `build:core` script that targeted the deleted `packages/agents` workspace.
- Remove internal lockfile-milestone wording from the unsupported `git:` source error and add a patch changeset.
- Make the human-notice integration assertion independent of agent-environment detection.
- Remove three unnecessary type assertions that blocked the current PR lint suite.
- Document nearest-declaration `intent.skills`, accumulated `intent.exclude`, kind-specific npm/workspace selectors, package-level permission, and notice behavior.
- Separate Available, Permitted, Loaded, Delivered, Activated, and Applied, and narrow `load` and hook guarantees to what Intent can observe.

## Non-goals

This preparation PR does not introduce accepted state, `intent.lock`, snapshots, new delivery modes, symlink delivery, hooks or hook behavior changes, activation, agent target selection, new configuration, new APIs, new commands, automatic `prepare` changes, registries, hosted services, or new consumer workflows.

## Follow-ups

The planned accepted-state PR is the next product step. Delivery, maintainer experience, activation, and stable-release hardening remain separate follow-up work.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/intent/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `CI=1 pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).