### PR TITLE
refactor(intent): remove duplicate source validation

### DIFF
--- a/packages/intent/src/core/skill-sources.ts
+++ b/packages/intent/src/core/skill-sources.ts
@@ -184,8 +184,6 @@ function packageSource(
 ): SkillSource | SkillSourceIssue {
   const hashIndex = selector.indexOf('#')
   if (hashIndex === -1) {
-    const invalid = validateId(selector)
-    if (invalid) return { raw, message: invalid }
     return selector.includes('*')
       ? { raw, pattern: selector, kind }
       : { raw, id: selector, kind }


### PR DESCRIPTION
Removes duplicate no-hash package source validation after `parseEntry` has already validated the selector. Hash selector validation remains unchanged.

Tests: `pnpm vitest run tests/skill-sources.test.ts`; `pnpm test:types`; `pnpm test:eslint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selectors without a hash are now accepted without additional validation and used directly when creating sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->