### PR TITLE
fix: fail closed on invalid project policy manifests

### DIFF
--- a/.changeset/quiet-policy-errors.md
+++ b/.changeset/quiet-policy-errors.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Stop policy-controlled skill listing and loading when a project policy manifest is unreadable, malformed, or not a JSON object. Report the manifest path instead of treating failed reads as missing policy and exposing skills. Preserve migration behavior for genuinely missing manifests.

--- a/docs/concepts/trust-model.md
+++ b/docs/concepts/trust-model.md
@@ -13,6 +13,8 @@ A package ships skills in a `skills/` directory. Discovery finds every installed
 
 The gate is opt-in today. A project with no `intent.skills` key still surfaces every discovered package, and Intent prints a deprecation notice to stderr on each run until you set `intent.skills`. A future version will require an explicit allowlist. See the [special forms](./configuration#special-forms) in Configuration.
 
+A missing policy manifest is distinct from an invalid one. If a `package.json` used for project policy cannot be read, contains invalid JSON, or is not a JSON object, Intent stops policy-controlled listing and loading with an error naming the file. This includes inherited policy within a resolved workspace. If malformed JSON prevents workspace discovery from identifying the root itself, that remains a [known limitation](https://github.com/TanStack/intent/issues/240).
+
 Trust does not propagate. A listed package may depend on another package that ships skills, but that dependency stays unlisted unless another entry matches it. A bare entry such as `foo` permits an npm source, while `workspace:foo` permits a workspace source. Their wildcard forms remain kind-specific. The exact `*` entry permits every discovered npm and workspace source.
 
 ## Static discovery

--- a/packages/intent/src/core/package-json.ts
+++ b/packages/intent/src/core/package-json.ts
@@ -1,12 +1,37 @@
-import { readFileSync } from 'node:fs'
+import { lstatSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 export function readPackageJson(dir: string): Record<string, unknown> | null {
+  const filePath = join(dir, 'package.json')
+  let content: string
   try {
-    return JSON.parse(
-      readFileSync(join(dir, 'package.json'), 'utf8'),
-    ) as Record<string, unknown>
-  } catch {
-    return null
+    content = readFileSync(filePath, 'utf8')
+  } catch (err) {
+    if (
+      (err as NodeJS.ErrnoException).code === 'ENOENT' &&
+      !lstatSync(filePath, { throwIfNoEntry: false })
+    ) {
+      return null
+    }
+    throw new Error(
+      `Failed to read Intent policy from ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+    )
   }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    throw new Error(
+      `Failed to parse Intent policy from ${filePath}: invalid JSON.`,
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      `Invalid Intent policy manifest ${filePath}: expected a JSON object.`,
+    )
+  }
+
+  return parsed as Record<string, unknown>
 }

--- a/packages/intent/tests/core.test.ts
+++ b/packages/intent/tests/core.test.ts
@@ -92,6 +92,102 @@ afterEach(() => {
 })
 
 describe('listIntentSkills', () => {
+  it('preserves migration mode when the project manifest is missing', () => {
+    writeInstalledIntentPackage(root, {
+      name: '@tanstack/query',
+      version: '5.0.0',
+      skillName: 'fetching',
+      description: 'Query data fetching patterns',
+    })
+
+    expect(
+      listIntentSkills({ cwd: root }).skills.map((skill) => skill.use),
+    ).toEqual(['@tanstack/query#fetching'])
+    expect(
+      loadIntentSkill('@tanstack/query#fetching', { cwd: root }).content,
+    ).toContain('Skill content here.')
+  })
+
+  it('rejects malformed project policy instead of enabling migration mode', () => {
+    writeInstalledIntentPackage(root, {
+      name: '@tanstack/query',
+      version: '5.0.0',
+      skillName: 'fetching',
+      description: 'Query data fetching patterns',
+    })
+    const packageJsonPath = join(root, 'package.json')
+    writeFileSync(packageJsonPath, '{"intent":{"skills":[]},')
+
+    expect(() => listIntentSkills({ cwd: root })).toThrow(packageJsonPath)
+    expect(() =>
+      loadIntentSkill('@tanstack/query#fetching', { cwd: root }),
+    ).toThrow(packageJsonPath)
+  })
+
+  it.each([null, [], 'invalid', 42, false])(
+    'rejects a non-object policy manifest: %j',
+    (manifest) => {
+      writeJson(join(root, 'package.json'), manifest)
+
+      expect(() => listIntentSkills({ cwd: root })).toThrow(
+        'expected a JSON object',
+      )
+      expect(() =>
+        loadIntentSkill('@tanstack/query#fetching', { cwd: root }),
+      ).toThrow('expected a JSON object')
+    },
+  )
+
+  it('rejects an unreadable policy manifest', () => {
+    const packageJsonPath = join(root, 'package.json')
+    mkdirSync(packageJsonPath)
+
+    expect(() => listIntentSkills({ cwd: root })).toThrow(
+      `Failed to read Intent policy from ${packageJsonPath}`,
+    )
+    expect(() =>
+      loadIntentSkill('@tanstack/query#fetching', { cwd: root }),
+    ).toThrow(`Failed to read Intent policy from ${packageJsonPath}`)
+  })
+
+  it('rejects a dangling policy symlink instead of treating it as missing', () => {
+    const packageJsonPath = join(root, 'package.json')
+    symlinkSync(join(root, 'missing.json'), packageJsonPath)
+
+    expect(() => listIntentSkills({ cwd: root })).toThrow(packageJsonPath)
+    expect(() =>
+      loadIntentSkill('@tanstack/query#fetching', { cwd: root }),
+    ).toThrow(packageJsonPath)
+  })
+
+  it('rejects malformed inherited policy even when the child permits the skill', () => {
+    const appDir = join(root, 'packages', 'app')
+    const packageJsonPath = join(root, 'package.json')
+    writeFileSync(
+      join(root, 'pnpm-workspace.yaml'),
+      'packages:\n  - packages/*\n',
+    )
+    writeFileSync(
+      packageJsonPath,
+      '{"workspaces":["packages/*"],"intent":{"exclude":["@tanstack/query"]},',
+    )
+    writeJson(join(appDir, 'package.json'), {
+      name: 'app',
+      intent: { skills: ['@tanstack/query'] },
+    })
+    writeInstalledIntentPackage(appDir, {
+      name: '@tanstack/query',
+      version: '5.0.0',
+      skillName: 'fetching',
+      description: 'Query data fetching patterns',
+    })
+
+    expect(() => listIntentSkills({ cwd: appDir })).toThrow(packageJsonPath)
+    expect(() =>
+      loadIntentSkill('@tanstack/query#fetching', { cwd: appDir }),
+    ).toThrow(packageJsonPath)
+  })
+
   it('returns a flat skill list and package summaries', () => {
     writeJson(join(root, 'package.json'), {
       name: 'test-app',

--- a/packages/intent/tests/integration/source-policy-surfaces.test.ts
+++ b/packages/intent/tests/integration/source-policy-surfaces.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   realpathSync,
@@ -75,6 +76,36 @@ describe('source policy — all four surfaces filter excluded and unlisted', () 
     writeIntentPackage(root, UNLISTED, 'core')
     writeIntentPackage(root, EXCLUDED, 'core')
   }
+
+  it.each([
+    ['list', '--json'],
+    ['load', `${LISTED}#core`],
+    ['load', `${LISTED}#core`, '--json'],
+    ['load', `${LISTED}#core`, '--path'],
+    ['install', '--map'],
+  ])(
+    'fails without delivering skills for malformed policy: %j',
+    async (...args) => {
+      writeStandaloneFixture()
+      const packageJsonPath = join(root, 'package.json')
+      writeFileSync(packageJsonPath, '{"intent":{"skills":[]},')
+      process.env.INTENT_GLOBAL_NODE_MODULES = join(root, 'empty-global')
+      process.chdir(root)
+      const stdoutSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true)
+
+      const exitCode = await main(args)
+
+      expect(exitCode).toBe(1)
+      expect(logSpy).not.toHaveBeenCalled()
+      expect(stdoutSpy).not.toHaveBeenCalled()
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(packageJsonPath),
+      )
+      expect(existsSync(join(root, 'AGENTS.md'))).toBe(false)
+    },
+  )
 
   it('list surfaces only the listed package', () => {
     writeStandaloneFixture()


### PR DESCRIPTION
## 🎯 Changes

A malformed project `package.json` was treated as missing policy, which could turn a deny-all allowlist into migration-mode access to every discovered skill. Policy reads now reject unreadable files, invalid JSON, and non-object manifests with a diagnostic identifying the file. A dangling manifest symlink also fails; genuinely missing manifests retain existing migration behavior.

Regression tests cover core listing/loading, inherited exclusions within a resolved workspace, and CLI list/load/default-install/install-map failures without skill output or generated guidance. Includes a patch changeset and trust-model documentation.

Fixes #230.

Workspace-boundary detection remains separate in #240: malformed npm root JSON can hide the workspace itself. This PR handles confirmed project policy files and inherited policy within a resolved workspace.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/intent/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Verification: 588 unit tests and 73 integration tests passed, along with types, ESLint, Knip, Sherif, documentation links, build, and `git diff --check`. Local PR checks used `NX_NO_CLOUD=true`, `NX_DAEMON=false`, a temporary npm cache, and `pnpm_config_verify_deps_before_run=false` to reuse installed dependencies in the isolated worktree.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Policy-controlled skill listing, loading, and installation now stop with a clear error when the project policy manifest is unreadable, malformed, or has an invalid format.
  - Error messages identify the affected manifest path, including inherited project policies.
  - Missing policy manifests continue to support existing migration behavior.

- **Documentation**
  - Updated the trust model documentation to explain how missing and invalid policy manifests are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->