### PR TITLE
fix: recognize workspace-root Intent devDependency

### DIFF
--- a/.changeset/workspace-root-intent-warning.md
+++ b/.changeset/workspace-root-intent-warning.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Recognize Intent installed as a devDependency at the owning workspace root when validating package skills.

--- a/packages/intent/src/commands/validate.ts
+++ b/packages/intent/src/commands/validate.ts
@@ -98,8 +98,24 @@ function collectPackagingWarnings(context: ProjectContext): Array<string> {
   if (!existsSync(pkgJsonPath)) return []
 
   let pkgJson: Record<string, unknown>
+  let devDeps: Record<string, string> | undefined
   try {
     pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'))
+    devDeps = pkgJson.devDependencies as Record<string, string> | undefined
+    if (
+      !devDeps?.['@tanstack/intent'] &&
+      context.workspaceRoot &&
+      context.workspaceRoot !== context.packageRoot
+    ) {
+      const workspaceManifestPath = join(context.workspaceRoot, 'package.json')
+      if (existsSync(workspaceManifestPath)) {
+        const workspaceManifest = JSON.parse(
+          readFileSync(workspaceManifestPath, 'utf8'),
+        ) as Record<string, unknown>
+        devDeps = workspaceManifest.devDependencies as
+          Record<string, string> | undefined
+      }
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     return [`Could not parse package.json: ${msg}`]
@@ -107,7 +123,6 @@ function collectPackagingWarnings(context: ProjectContext): Array<string> {
 
   const warnings: Array<string> = []
 
-  const devDeps = pkgJson.devDependencies as Record<string, string> | undefined
   if (!devDeps?.['@tanstack/intent']) {
     warnings.push('@tanstack/intent is not in devDependencies')
   }

--- a/packages/intent/tests/cli.test.ts
+++ b/packages/intent/tests/cli.test.ts
@@ -3197,6 +3197,62 @@ describe('cli commands', () => {
     expect(output).toContain('Framework skills must have a "requires" field')
   })
 
+  it.each(['package.json', 'pnpm-workspace.yaml'])(
+    'recognizes Intent at the workspace root declared by %s',
+    async (workspaceFile) => {
+      const root = mkdtempSync(
+        join(realTmpdir, 'intent-cli-validate-root-dep-'),
+      )
+      tempDirs.push(root)
+      const manifest = {
+        private: true,
+        ...(workspaceFile === 'package.json'
+          ? { workspaces: ['packages/*'] }
+          : {}),
+        devDependencies: { '@tanstack/intent': '^0.4.0' },
+      }
+      writeJson(join(root, 'package.json'), manifest)
+      if (workspaceFile === 'pnpm-workspace.yaml')
+        writeFileSync(
+          join(root, 'pnpm-workspace.yaml'),
+          'packages:\n  - packages/*\n',
+        )
+      const packageDir = join(root, 'packages', 'client')
+      writeJson(join(packageDir, 'package.json'), {
+        name: 'client',
+        keywords: ['tanstack-intent'],
+        files: ['skills'],
+      })
+      writeSkillMd(join(packageDir, 'skills', 'query'), {
+        name: 'query',
+        description: 'Query the client.',
+      })
+
+      for (const cwd of [root, packageDir]) {
+        process.chdir(cwd)
+        logSpy.mockClear()
+        expect(await main(['validate'])).toBe(0)
+        expect(logSpy.mock.calls.flat().join('\n')).not.toContain(
+          '@tanstack/intent is not in devDependencies',
+        )
+      }
+
+      writeJson(join(root, 'package.json'), {
+        ...manifest,
+        devDependencies: {},
+      })
+      writeJson(join(root, 'packages', 'tooling', 'package.json'), {
+        name: 'tooling',
+        devDependencies: { '@tanstack/intent': '^0.4.0' },
+      })
+      logSpy.mockClear()
+      expect(await main(['validate'])).toBe(0)
+      expect(logSpy.mock.calls.flat().join('\n')).toContain(
+        '@tanstack/intent is not in devDependencies',
+      )
+    },
+  )
+
   it('validates package skills from repo root without root packaging warnings', async () => {
     const root = mkdtempSync(join(realTmpdir, 'intent-cli-validate-mono-'))
     tempDirs.push(root)


### PR DESCRIPTION
## 🎯 Changes

Stacked on #265. Fixes #212.

Recognize `@tanstack/intent` in the owning workspace root's devDependencies when validating a member package. Keep package-local declarations valid and preserve the warning when Intent is declared only by a sibling package. Package keywords and publishing checks still use the member's manifest.

Regression tests cover package.json and pnpm workspace declarations, invocation from the workspace root and member directory, and removal of the root declaration.

Verification: all 146 CLI tests passed; package typecheck, focused ESLint, Prettier, and `git diff --check` passed. Three existing lint warnings remain. No dependency, guide, or CI changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/intent/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).