### PR TITLE
ci: pin changesets/action to v1 for Changesets CLI v2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,5 +16,12 @@
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "postUpdateOptions": ["pnpmDedupe"],
-  "ignoreDeps": ["@types/node", "node"]
+  "ignoreDeps": ["@types/node", "node"],
+  "packageRules": [
+    {
+      "description": "changesets/action v2 requires @changesets/cli v3. Hold the action at v1 until the CLI is upgraded.",
+      "matchPackageNames": ["changesets/action"],
+      "allowedVersions": "<2"
+    }
+  ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           fi
       - name: Create Release Pull Request or Publish
         id: changesets-action
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm run changeset:version
           publish: pnpm run changeset:publish ${{ steps.dist-tag.outputs.tag && format('--tag {0}', steps.dist-tag.outputs.tag) }}


### PR DESCRIPTION
## 🎯 Changes

Renovate updated `changesets/action` to v2 in #246. The v2 action requires Changesets CLI v3, and every `release.yml` run since Sept 5 has failed at "Create Release Pull Request or Publish" with:

```
This version of the Changesets action is designed to work with Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.
```

No version PR has been created since. This pins the action back to v1.9.0 and adds a Renovate rule holding it below v2 until `@changesets/cli` is upgraded to v3, which is a separate dependency decision.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/intent/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release configuration to maintain compatibility with the current Changesets tooling.
  * Pinned the release workflow to a specific Changesets action version for more consistent release processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->