### PR TITLE
fix: make maintainer commands and the unit suite work on Windows

### DIFF
--- a/.changeset/windows-markdown-escapes.md
+++ b/.changeset/windows-markdown-escapes.md
@@ -2,4 +2,4 @@
 '@tanstack/intent': patch
 ---
 
-Preserve backslash escapes in Markdown link destinations when `intent load` and `intent meta` rewrite relative paths on Windows. Previously an escaped character such as `\)` was normalized into a path separator.
+Fix Windows path handling. Preserve backslash escapes in Markdown link destinations when `intent load` and `intent meta` rewrite relative paths (an escaped `\)` was normalized into a path separator). Normalize the Git repository root reported by `git rev-parse` so `intent maintainer add` no longer rejects every skill path with "must belong to the selected package", and print repository-relative paths in maintainer output and `maintainer status --json` with forward slashes on every platform.

--- a/.changeset/windows-markdown-escapes.md
+++ b/.changeset/windows-markdown-escapes.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Preserve backslash escapes in Markdown link destinations when `intent load` and `intent meta` rewrite relative paths on Windows. Previously an escaped character such as `\)` was normalized into a path separator.

--- a/packages/intent/src/commands/maintainer.ts
+++ b/packages/intent/src/commands/maintainer.ts
@@ -324,7 +324,7 @@ export async function runMaintainerCommand(
       }
       const preview = planAdoptionChanges(project, chosen)
       const files = preview.changes.map((change) =>
-        relative(project.root, change.path),
+        relative(project.root, change.path).replaceAll('\\', '/'),
       )
       if (!(await prompts.confirm(chosen, files))) {
         console.log('Adoption canceled. No files changed.')
@@ -419,9 +419,11 @@ export async function runMaintainerCommand(
     schemaVersion: 1,
     root: project.root,
     artifacts: project.artifacts,
-    skills: plan.skills.map((path) => relative(project.root, path)),
+    skills: plan.skills.map((path) =>
+      relative(project.root, path).replaceAll('\\', '/'),
+    ),
     staleFiles: plan.changes.map((change) =>
-      relative(project.root, change.path),
+      relative(project.root, change.path).replaceAll('\\', '/'),
     ),
     problems: plan.problems,
     distribution: {

--- a/packages/intent/src/core/markdown.ts
+++ b/packages/intent/src/core/markdown.ts
@@ -1,6 +1,9 @@
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { toPosixPath } from '../shared/utils.js'
 
+/** Private-use character that no path function treats as a separator. */
+const BACKSLASH_PLACEHOLDER = '\uE000'
+
 function resolveFromCwd(path: string): string {
   return resolve(process.cwd(), path)
 }
@@ -171,7 +174,13 @@ function rewriteMarkdownDestination({
   const { pathPart, suffix } = splitDestinationSuffix(destination)
   if (isExternalOrAbsoluteDestination(pathPart)) return destination
 
-  const resolvedDestinationPath = resolve(context.skillDir, pathPart)
+  // A backslash in a Markdown destination is an escape (`\)`), never a path
+  // separator. Hide it from the path functions, which on Windows would
+  // otherwise normalize it into `/`, and restore it in the rewritten output.
+  const resolvedDestinationPath = resolve(
+    context.skillDir,
+    pathPart.replaceAll('\\', BACKSLASH_PLACEHOLDER),
+  )
   const relativeToPackageRoot = relative(
     context.resolvedPackageRoot,
     resolvedDestinationPath,
@@ -191,7 +200,7 @@ function rewriteMarkdownDestination({
       ? relativeToCwd
       : resolvedDestinationPath
 
-  const rewritten = `${toPosixPath(rewrittenPath)}${suffix}`
+  const rewritten = `${toPosixPath(rewrittenPath).replaceAll(BACKSLASH_PLACEHOLDER, '\\')}${suffix}`
   context.rewrittenDestinations.set(destination, rewritten)
   return rewritten
 }

--- a/packages/intent/src/maintainer/add.ts
+++ b/packages/intent/src/maintainer/add.ts
@@ -171,7 +171,7 @@ export function planAddSkills(
       })
     }
     nextSpec = `${nextSpec.trimEnd()}\n\n- Registered \`${name}\` in \`${packageDir ?? '.'}\` (domain \`${options.domain}\`).${tasks.length ? ` Developer tasks: ${tasks.join('; ')}.` : ''} ${tasks.length ? 'Decisions and checks' : 'Task coverage, decisions, and checks'} still need to be recorded.\n`
-    paths.push(join(packageDir ?? '', entry.path))
+    paths.push(join(packageDir ?? '', entry.path).replaceAll('\\', '/'))
   }
   if (additions.length) {
     changes.push(

--- a/packages/intent/src/maintainer/project.ts
+++ b/packages/intent/src/maintainer/project.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, lstatSync, readFileSync } from 'node:fs'
-import { basename, dirname, join, relative } from 'node:path'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 import { parseDocument, stringify } from 'yaml'
 import { resolveProjectContext } from '../core/project-context.js'
 import { writeChanges } from './files.js'
@@ -40,11 +40,15 @@ export function resolveMaintainerProject(
 ): MaintainerProject {
   let root: string
   try {
-    root = execFileSync(
-      'git',
-      ['-c', 'core.fsmonitor=false', 'rev-parse', '--show-toplevel'],
-      { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
-    ).trim()
+    // Git prints forward slashes on every platform; normalize so the root
+    // compares equal to paths built with node:path (backslashes on Windows).
+    root = resolve(
+      execFileSync(
+        'git',
+        ['-c', 'core.fsmonitor=false', 'rev-parse', '--show-toplevel'],
+        { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      ).trim(),
+    )
   } catch {
     throw new Error('Maintainer commands require a Git working tree.')
   }
@@ -164,7 +168,9 @@ export function skillPath(
 export function setupRecords(project: MaintainerProject): Array<string> {
   const changes = planSetupRecords(project)
   writeChanges(project.root, changes)
-  return changes.map((change) => relative(project.root, change.path))
+  return changes.map((change) =>
+    relative(project.root, change.path).replaceAll('\\', '/'),
+  )
 }
 
 export function planSetupRecords(

--- a/packages/intent/src/review/review.ts
+++ b/packages/intent/src/review/review.ts
@@ -354,7 +354,9 @@ function reviewIgnorePatterns(tree: Record<string, unknown>, path: string) {
 export function createReview(cwd: string, baseRef?: string): ReviewReport {
   let root: string
   try {
-    root = git(resolve(cwd), ['rev-parse', '--show-toplevel']).trim()
+    // Git prints forward slashes on every platform; normalize so the root
+    // compares equal to paths built with node:path (backslashes on Windows).
+    root = resolve(git(resolve(cwd), ['rev-parse', '--show-toplevel']).trim())
   } catch {
     throw new Error(
       'Skill review requires a Git working tree with an initial commit.',

--- a/packages/intent/tests/cli.test.ts
+++ b/packages/intent/tests/cli.test.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as discovery from '../src/discovery/scanner.js'
@@ -163,21 +163,24 @@ describe('intent meta', () => {
     const root = mkdtempSync(join(realTmpdir, 'intent-meta-reference-'))
     tempDirs.push(root)
     process.chdir(root)
+    // Rewritten destinations always use forward slashes, on every platform.
+    const referencePath = (name: string) =>
+      join(metaDir, 'domain-discovery', 'references', name).split(sep).join('/')
     const expected = readFileSync(
       join(metaDir, 'domain-discovery', 'SKILL.md'),
       'utf8',
     )
       .replaceAll(
         '(references/deep-read.md)',
-        `(${join(metaDir, 'domain-discovery', 'references', 'deep-read.md')})`,
+        `(${referencePath('deep-read.md')})`,
       )
       .replaceAll(
         '(references/deep-read.md#reading-order)',
-        `(${join(metaDir, 'domain-discovery', 'references', 'deep-read.md')}#reading-order)`,
+        `(${referencePath('deep-read.md')}#reading-order)`,
       )
       .replaceAll(
         '(references/artifacts.md)',
-        `(${join(metaDir, 'domain-discovery', 'references', 'artifacts.md')})`,
+        `(${referencePath('artifacts.md')})`,
       )
       .replaceAll(
         '(../generate-skill/SKILL.md)',

--- a/packages/intent/tests/cli.test.ts
+++ b/packages/intent/tests/cli.test.ts
@@ -211,8 +211,10 @@ describe('intent meta', () => {
     )
     const format = join('generate-skill', 'references', 'skill-format.md')
     const distribution = join('generate-skill', 'references', 'distribution.md')
-    expect(output).toContain(`](${join(metaDir, format)})`)
-    expect(output).toContain(`](${join(metaDir, distribution)})`)
+    // Rewritten destinations always use forward slashes, on every platform.
+    const posix = (path: string) => path.split(sep).join('/')
+    expect(output).toContain(`](${posix(join(metaDir, format))})`)
+    expect(output).toContain(`](${posix(join(metaDir, distribution))})`)
     for (const path of [
       format,
       distribution,

--- a/packages/intent/tests/hooks-install.test.ts
+++ b/packages/intent/tests/hooks-install.test.ts
@@ -649,6 +649,11 @@ console.log(JSON.stringify({
   return `${quoteShell(process.execPath)} ${quoteShell(scriptPath)}`
 }
 
+// The hook runner executes the catalog command with `shell: true`, which is
+// cmd.exe on Windows: it understands double quotes, never single quotes.
 function quoteShell(value: string): string {
+  if (process.platform === 'win32') {
+    return `"${value.replace(/"/g, '""')}"`
+  }
   return `'${value.replace(/'/g, `'\\''`)}'`
 }

--- a/packages/intent/tests/review.test.ts
+++ b/packages/intent/tests/review.test.ts
@@ -64,6 +64,9 @@ function accept(report = createReview(root)) {
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'intent-review-'))
   git('init', '-q')
+  // Keep the fixture independent of the developer's global excludes file,
+  // which may ignore files these tests rely on (for example CLAUDE.md).
+  git('config', 'core.excludesFile', join(root, '.no-global-excludes'))
   git('config', 'user.name', 'Fixture')
   git('config', 'user.email', 'fixture@example.invalid')
   write(


### PR DESCRIPTION
## Summary

`pnpm test:lib` in `packages/intent` had 25 failures on Windows 11 (6 before the maintainer CLI landed, 25 after). Two of the root causes are real user-facing bugs on Windows; the rest are test-side assumptions.

**User-facing fixes** (changeset included)

- **Markdown destination rewriting mangled escapes.** `rewriteLoadedSkillMarkdownDestinations` ran destinations through win32 `resolve`/`relative`, which treat `\` as a separator, so an escaped destination like `assets/flow\).png` came out as `assets/flow/).png` from `intent load` and `intent meta`. Backslashes are hidden behind a private-use placeholder while resolving and restored afterwards.
- **`intent maintainer add` failed on every skill path** with "The skill path must belong to the selected package." `git rev-parse --show-toplevel` prints forward slashes on Windows while `resolveProjectContext` builds paths with backslashes, so the string comparison never matched. The maintainer project root and the review root are now normalized with `resolve`.
- **Maintainer output paths** (`Registered …`, adoption previews, `maintainer status --json` `skills`/`staleFiles`) now use forward slashes on every platform, matching the rest of the maintainer code.

**Test-side fixes**

- Both `intent meta` tests built expected link paths with the platform separator; the command always prints forward slashes.
- Hook tests quoted the fake catalog command with single quotes, but the runner executes it with `shell: true` (cmd.exe on Windows). The helper now double-quotes on win32.
- The review fixture inherited the developer's global `core.excludesFile` (mine ignores `CLAUDE.md`, which one test depends on). The fixture now pins `core.excludesFile` to a path inside the temp repo.
