### PR TITLE
perf: resolve dependency directories without Node's module resolver

### DIFF
--- a/.changeset/fast-dep-resolution.md
+++ b/.changeset/fast-dep-resolution.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Speed up dependency discovery. Resolve each dependency directory with a plain `node_modules` walk plus a single symlink collapse instead of Node's module resolver, which evaluated export maps and realpathed every path segment per lookup, and resolve each package's real root once per package instead of once per skill. `intent list` in a pnpm monorepo runs roughly 30% faster; discovered packages and paths are unchanged.

--- a/packages/intent/src/discovery/scanner.ts
+++ b/packages/intent/src/discovery/scanner.ts
@@ -269,18 +269,35 @@ function deriveIntentConfig(
 // Skill discovery within a package
 // ---------------------------------------------------------------------------
 
+/**
+ * Real path of the package root that owns `skillsDir`, or null when it cannot
+ * be resolved. Computed once per package: every skill entry is checked against
+ * the same root, so resolving it per skill only repeated the same syscalls.
+ */
+function resolveRealPackageRoot(
+  skillsDir: string,
+  readFs: ReadFs,
+): string | null {
+  try {
+    return readFs.realpathSync.native(dirname(skillsDir))
+  } catch {
+    return null
+  }
+}
+
 function readSkillEntry(
   skillsDir: string,
+  realPackageRoot: string | null,
   childDir: string,
   skillFile: string,
   readFs: ReadFs = nodeReadFs,
 ): SkillEntry | null {
   if (!readFs.openSync || !readFs.fstatSync || !readFs.closeSync) return null
+  if (realPackageRoot === null) return null
   let fd: number | undefined
   let fm: Record<string, unknown> | null
   try {
     const realSkillFile = readFs.realpathSync.native(skillFile)
-    const realPackageRoot = readFs.realpathSync.native(dirname(skillsDir))
     if (!isWithinOrEqual(realSkillFile, realPackageRoot)) return null
     const expected = readFs.lstatSync(realSkillFile)
     if (!expected.isFile()) return null
@@ -331,6 +348,7 @@ function discoverSkillByNameHint(
   const skills: Array<SkillEntry> = []
   const seen = new Set<string>()
   const skillNameHints = getSkillNameHints(packageName, skillNameHint)
+  let realPackageRoot: string | null | undefined
 
   for (const hint of skillNameHints) {
     const resolvedHint = resolveSkillNameHintPath(skillsDir, hint)
@@ -339,10 +357,19 @@ function discoverSkillByNameHint(
     const { childDir, skillFile } = resolvedHint
     if (!readFs.existsSync(skillFile)) continue
 
+    if (includeMetadata) {
+      realPackageRoot ??= resolveRealPackageRoot(skillsDir, readFs)
+    }
     // Keep the hinted identity so loading can report its existing path error,
     // without reading metadata from an unreadable or escaping target.
     const skill = (includeMetadata
-      ? readSkillEntry(skillsDir, childDir, skillFile, readFs)
+      ? readSkillEntry(
+          skillsDir,
+          realPackageRoot ?? null,
+          childDir,
+          skillFile,
+          readFs,
+        )
       : null) ?? {
       name: hint,
       path: skillFile,
@@ -364,20 +391,27 @@ function discoverSkills(
   warnings: Array<string>,
 ): Array<SkillEntry> {
   const readFs = fsCache.getReadFs()
-  return fsCache
-    .findSkillFiles(skillsDir)
-    .flatMap((skillFile): Array<SkillEntry> => {
-      const childDir = dirname(skillFile)
-      if (childDir === skillsDir) return []
-      const skill = readSkillEntry(skillsDir, childDir, skillFile, readFs)
-      if (!skill) {
-        warnings.push(
-          `Skipped unreadable or out-of-package skill metadata for "${packageName}".`,
-        )
-        return []
-      }
-      return [skill]
-    })
+  const skillFiles = fsCache.findSkillFiles(skillsDir)
+  const realPackageRoot =
+    skillFiles.length > 0 ? resolveRealPackageRoot(skillsDir, readFs) : null
+  return skillFiles.flatMap((skillFile): Array<SkillEntry> => {
+    const childDir = dirname(skillFile)
+    if (childDir === skillsDir) return []
+    const skill = readSkillEntry(
+      skillsDir,
+      realPackageRoot,
+      childDir,
+      skillFile,
+      readFs,
+    )
+    if (!skill) {
+      warnings.push(
+        `Skipped unreadable or out-of-package skill metadata for "${packageName}".`,
+      )
+      return []
+    }
+    return [skill]
+  })
 }
 
 function getPackageShortName(packageName: string): string {

--- a/packages/intent/src/shared/utils.ts
+++ b/packages/intent/src/shared/utils.ts
@@ -10,8 +10,7 @@ import {
   readdirSync,
   realpathSync,
 } from 'node:fs'
-import { createRequire } from 'node:module'
-import { dirname, join, resolve, sep } from 'node:path'
+import { basename, dirname, join, resolve, sep } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import type { Dirent } from 'node:fs'
 
@@ -313,67 +312,50 @@ export function detectGlobalNodeModules(packageManager: string): {
 }
 
 /**
- * Resolve the directory of a dependency by name. Tries createRequire first
- * (handles pnpm symlinks), then falls back to walking up node_modules
- * directories (handles packages with export maps that block ./package.json).
+ * Resolve the directory of a dependency by name by walking up from
+ * `parentDir` and checking `node_modules/<depName>/package.json` at each
+ * ancestor, the same lookup order Node uses. A symlinked match (pnpm's
+ * virtual store, workspace links) is collapsed to its real directory so
+ * callers see one identity per installed package.
+ *
+ * This deliberately avoids `createRequire().resolve`: Node's resolver
+ * evaluates export maps, reads the nearest package.json, and realpaths every
+ * path segment on each call. In a pnpm monorepo that dominated scan time, and
+ * the walk below already covers every layout the resolver handled (nested,
+ * hoisted, and virtual-store siblings) without executing package code.
  */
-/**
- * `createRequire` builds a full module-resolution context; constructing it is
- * non-trivial and `resolveDepDir` is called once per dependency, often many
- * times from the same `parentDir` (every sibling dep of one package). Cache the
- * require function by its base `package.json` path. `req.resolve` still hits the
- * live filesystem on each call, so cached entries never go stale.
- */
-const requireForBaseCache = new Map<string, ReturnType<typeof createRequire>>()
-
-function getRequireForBase(
-  basePackageJson: string,
-): ReturnType<typeof createRequire> {
-  let req = requireForBaseCache.get(basePackageJson)
-  if (!req) {
-    req = createRequire(basePackageJson)
-    requireForBaseCache.set(basePackageJson, req)
-  }
-  return req
-}
-
 export function resolveDepDir(
   depName: string,
   parentDir: string,
 ): string | null {
-  // Try createRequire — works for most packages including pnpm virtual store
-  try {
-    const req = getRequireForBase(join(parentDir, 'package.json'))
-    const pkgJsonPath = req.resolve(join(depName, 'package.json'))
-    return dirname(pkgJsonPath)
-  } catch (err: unknown) {
-    const code =
-      err && typeof err === 'object' && 'code' in err
-        ? (err as NodeJS.ErrnoException).code
-        : undefined
-    if (
-      code &&
-      code !== 'MODULE_NOT_FOUND' &&
-      code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED'
-    ) {
-      console.warn(
-        `Warning: could not resolve ${depName} from ${parentDir}: ${err instanceof Error ? err.message : String(err)}`,
-      )
-    }
-  }
-
-  // Fallback: walk up from parentDir checking node_modules/<depName>.
-  // Handles packages with exports maps that don't expose ./package.json.
   let dir = parentDir
   let prev: string | undefined
   while (dir !== prev) {
-    const candidate = join(dir, 'node_modules', depName)
-    if (existsSync(join(candidate, 'package.json'))) return candidate
+    // Node skips ancestors that are themselves node_modules directories
+    // (`.../node_modules/node_modules/<dep>` is never a valid location).
+    if (basename(dir) !== 'node_modules') {
+      const candidate = join(dir, 'node_modules', depName)
+      if (existsSync(join(candidate, 'package.json'))) {
+        return resolveRealDir(candidate)
+      }
+    }
     prev = dir
     dir = dirname(dir)
   }
 
   return null
+}
+
+/**
+ * Collapse a symlinked directory to its real path with one `lstat` and, only
+ * when needed, one native `realpath` call. Non-links are returned as-is.
+ */
+function resolveRealDir(dir: string): string {
+  try {
+    return lstatSync(dir).isSymbolicLink() ? realpathSync.native(dir) : dir
+  } catch {
+    return dir
+  }
 }
 
 /**

--- a/packages/intent/tests/resolve-dep-dir.test.ts
+++ b/packages/intent/tests/resolve-dep-dir.test.ts
@@ -1,0 +1,75 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveDepDir } from '../src/shared/utils.js'
+
+let root: string
+
+function createPackage(...segments: Array<string>): string {
+  const dir = join(...segments)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), '{}')
+  return dir
+}
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'intent-resolve-dep-')))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('resolveDepDir', () => {
+  it('resolves a dependency nested under the parent package', () => {
+    const parent = createPackage(root, 'node_modules', 'parent')
+    const nested = createPackage(parent, 'node_modules', 'dep')
+    createPackage(root, 'node_modules', 'dep')
+
+    expect(resolveDepDir('dep', parent)).toBe(nested)
+  })
+
+  it('walks up to a hoisted dependency, including scoped names', () => {
+    const parent = createPackage(root, 'node_modules', 'parent')
+    const hoisted = createPackage(root, 'node_modules', '@scope', 'dep')
+
+    expect(resolveDepDir('@scope/dep', parent)).toBe(hoisted)
+  })
+
+  it('finds a virtual-store sibling without probing node_modules/node_modules', () => {
+    // pnpm layout: `.pnpm/parent@1/node_modules/parent` depends on a sibling
+    // `.pnpm/parent@1/node_modules/dep`; Node never looks inside
+    // `.pnpm/parent@1/node_modules/node_modules`.
+    const store = join(root, 'node_modules', '.pnpm', 'parent@1.0.0')
+    const parent = createPackage(store, 'node_modules', 'parent')
+    const sibling = createPackage(store, 'node_modules', 'dep')
+    createPackage(store, 'node_modules', 'node_modules', 'dep')
+
+    expect(resolveDepDir('dep', parent)).toBe(sibling)
+  })
+
+  it('collapses a symlinked match to its real directory', () => {
+    const real = createPackage(root, 'store', 'dep')
+    mkdirSync(join(root, 'node_modules'), { recursive: true })
+    symlinkSync(real, join(root, 'node_modules', 'dep'), 'junction')
+    const parent = createPackage(root, 'node_modules', 'parent')
+
+    expect(resolveDepDir('dep', parent)).toBe(real)
+  })
+
+  it('ignores a directory without package.json and returns null when nothing matches', () => {
+    const parent = createPackage(root, 'node_modules', 'parent')
+    mkdirSync(join(root, 'node_modules', 'dep'), { recursive: true })
+
+    expect(resolveDepDir('dep', parent)).toBeNull()
+    expect(resolveDepDir('missing', parent)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

First of a three-PR perf stack (this → lazy scan path → bundled deps).

`resolveDepDir` called `createRequire().resolve('<dep>/package.json')` for every dependency edge in the scan. Node's resolver evaluates export maps, reads the nearest `package.json`, and realpaths every path segment per call. A CPU profile of `intent list` at this repo's root (pnpm monorepo, 438 package.json reads) put 624 of ~940 ms inside that call, with `lstat` and `internalModuleStat` as the top self-time entries.

This PR:

- Replaces the resolver call with the plain `node_modules` ancestor walk the function already used as a fallback. It skips `node_modules/node_modules` ancestors like Node does and collapses a symlinked match (pnpm virtual store, workspace links) with one `lstat` plus one native `realpath`.
- Resolves a package's real root once per package in skill discovery instead of once per skill file (`readSkillEntry` did three realpath calls per skill).
- Adds a focused unit test for `resolveDepDir` covering nested, hoisted, scoped, virtual-store sibling, symlinked, and missing cases.

## Measurements (Windows 11, warm cache, import + run of `main(['list'])`)

| Scenario | main | this PR |
|---|---|---|
| repo root (pnpm monorepo) | ~770 ms | ~555 ms |
| `example/start-basic` (npm, 7 pkgs / 24 skills) | ~295 ms | ~230 ms |

`intent list --json` output on `example/start-basic` is byte-identical to main, and `--debug` stats (package.json read count) are unchanged at the repo root.

## Summary by CodeRabbit

* **Performance**
  * Improved dependency discovery speed, with `intent list` running approximately 30% faster in pnpm monorepos.
  * Preserved discovered packages and paths while reducing repeated dependency resolution work.

* **Bug Fixes**
  * Improved resolution of nested, scoped, workspace-linked, and pnpm-managed dependencies.
  * Preserved useful path warnings and fallback reporting when package metadata cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
