### PR TITLE
ci: ignore vitest by name in sherif so release checks pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "sherif": {
     "ignoreDependency": [
-      "vitest@4.1.8"
+      "vitest"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

The Release workflow on `main` fails at `root:test:sherif`:

```
Dependency vitest has multiple versions defined in the workspace.
  ./                  5.0.0
  ./benchmarks/intent 4.1.11
```

`benchmarks/intent` intentionally stays on vitest 4 because `@codspeed/vitest-plugin` (5.7.1, current latest) only declares `vitest: ^3.2 || ^4`. The root `sherif.ignoreDependency` entry was pinned to `vitest@4.1.8`, so the Renovate security bump to 4.1.11 in #261 silently invalidated it.

This ignores `vitest` by name so the split stays allowed until the CodSpeed plugin supports vitest 5. No changeset: repo tooling only.

## Test plan

- [x] `pnpm test:sherif` passes locally on top of current `main`
- [ ] Release workflow goes green after merge
