### PR TITLE
perf: keep semver and interactive prompts off the list/load startup path

### DIFF
--- a/.changeset/lean-scan-startup.md
+++ b/.changeset/lean-scan-startup.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Trim `intent list` and `intent load` startup. Discovery no longer loads the `semver` package on every run (a small built-in comparator picks between duplicate installed versions of a package, with identical results), and `intent install` loads its interactive prompt library only when it actually prompts.

--- a/packages/intent/src/commands/install/command.ts
+++ b/packages/intent/src/commands/install/command.ts
@@ -20,7 +20,6 @@ import {
   writeIntentSkillsBlock,
 } from './guidance.js'
 import { setupInitialPermissions } from './permissions.js'
-import { createPermissionPrompts } from './permission-prompts.js'
 import type { GlobalScanFlags } from '../support.js'
 import type { IntentCoreOptions } from '../../core/index.js'
 import type { ScanResult } from '../../shared/types.js'
@@ -308,7 +307,12 @@ export async function runInstallCommand(
           review: options.review,
           root: process.cwd(),
           runtime: {
-            prompts: runtime.permissionPrompts ?? createPermissionPrompts(),
+            // Loaded on demand: @clack/prompts is only needed when prompting.
+            prompts:
+              runtime.permissionPrompts ??
+              (
+                await import('./permission-prompts.js')
+              ).createPermissionPrompts(),
           },
         })
       } catch (error) {

--- a/packages/intent/src/discovery/scanner.ts
+++ b/packages/intent/src/discovery/scanner.ts
@@ -13,7 +13,6 @@ import {
   resolve,
   sep,
 } from 'node:path'
-import semver from 'semver'
 import {
   detectGlobalNodeModules,
   nodeReadFs,
@@ -26,6 +25,7 @@ import {
   findWorkspaceRoot,
   readWorkspacePatterns,
 } from '../setup/workspace-patterns.js'
+import { compareVersions, normalizeVersion } from '../shared/version.js'
 import { createIntentFsCache } from './fs-cache.js'
 import { detectPackageManager } from './package-manager.js'
 import { createDependencyWalker, createPackageRegistrar } from './index.js'
@@ -491,13 +491,6 @@ function getPackageDepth(packageRoot: string, projectRoot: string): number {
   return relative(projectRoot, packageRoot).split(sep).length
 }
 
-function normalizeVersion(version: string): string | null {
-  const validVersion = semver.valid(version)
-  if (validVersion) return validVersion
-
-  return semver.coerce(version)?.version ?? null
-}
-
 function comparePackageVersions(a: string, b: string): number {
   const versionA = normalizeVersion(a)
   const versionB = normalizeVersion(b)
@@ -508,7 +501,7 @@ function comparePackageVersions(a: string, b: string): number {
     return 0
   }
 
-  return semver.compare(versionA, versionB)
+  return compareVersions(versionA, versionB)
 }
 
 function formatVariantWarning(

--- a/packages/intent/src/shared/version.ts
+++ b/packages/intent/src/shared/version.ts
@@ -1,0 +1,154 @@
+/**
+ * Minimal semver helpers for the discovery scan path.
+ *
+ * The scanner only needs to pick the newer of two installed versions of the
+ * same package, and only when a duplicate is found. Pulling in the `semver`
+ * package for that cost ~28ms of module loading (46 CommonJS files) on every
+ * `intent list`, so this module reimplements just the three operations the
+ * scanner uses — `valid`, `coerce`, and `compare` — with the same results.
+ * Staleness checks still use `semver` for its richer API; they run only on
+ * `intent stale`.
+ */
+
+interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+  prerelease: Array<string | number>
+}
+
+// Mirrors semver's strict `FULL` pattern: optional `v`, three numeric
+// identifiers without leading zeros, optional prerelease and build metadata.
+const NUMERIC = '0|[1-9]\\d*'
+const PRERELEASE_IDENTIFIER = `(?:${NUMERIC}|\\d*[a-zA-Z-][a-zA-Z0-9-]*)`
+const BUILD_IDENTIFIER = '[0-9A-Za-z-]+'
+const FULL_VERSION = new RegExp(
+  `^v?(${NUMERIC})\\.(${NUMERIC})\\.(${NUMERIC})` +
+    `(?:-(${PRERELEASE_IDENTIFIER}(?:\\.${PRERELEASE_IDENTIFIER})*))?` +
+    `(?:\\+${BUILD_IDENTIFIER}(?:\\.${BUILD_IDENTIFIER})*)?$`,
+)
+
+// Mirrors semver's `COERCE` pattern: the first run of up to three dotted
+// numeric groups, each at most 16 digits, not embedded in a longer number.
+const COERCE =
+  /(?:^|[^\d])(\d{1,16})(?:\.(\d{1,16}))?(?:\.(\d{1,16}))?(?:$|[^\d])/
+
+const MAX_VERSION_LENGTH = 256
+
+function toNumber(value: string): number | null {
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+function parseVersion(version: string): ParsedVersion | null {
+  const trimmed = version.trim()
+  if (trimmed.length > MAX_VERSION_LENGTH) return null
+  const match = FULL_VERSION.exec(trimmed)
+  if (!match) return null
+
+  const major = toNumber(match[1]!)
+  const minor = toNumber(match[2]!)
+  const patch = toNumber(match[3]!)
+  if (major === null || minor === null || patch === null) return null
+
+  const prerelease = match[4]
+    ? match[4].split('.').map((identifier) => {
+        if (!/^\d+$/.test(identifier)) return identifier
+        const numeric = Number(identifier)
+        return Number.isSafeInteger(numeric) ? numeric : identifier
+      })
+    : []
+
+  return { major, minor, patch, prerelease }
+}
+
+function formatVersion(parsed: ParsedVersion): string {
+  const main = `${parsed.major}.${parsed.minor}.${parsed.patch}`
+  return parsed.prerelease.length > 0
+    ? `${main}-${parsed.prerelease.join('.')}`
+    : main
+}
+
+/**
+ * Equivalent to `semver.valid(version)`: the normalized version string (no
+ * leading `v`, no build metadata) when `version` is strict semver, else null.
+ */
+export function validVersion(version: string): string | null {
+  const parsed = parseVersion(version)
+  return parsed ? formatVersion(parsed) : null
+}
+
+/**
+ * Equivalent to `semver.coerce(version)?.version`: the first `x[.y[.z]]`
+ * run in `version` padded to `x.y.z`, else null.
+ */
+export function coerceVersion(version: string): string | null {
+  const match = COERCE.exec(version)
+  if (!match) return null
+  // Like semver, the coerced triple must itself be strict semver: leading
+  // zeros and numbers above MAX_SAFE_INTEGER make the result null.
+  return validVersion(`${match[1]}.${match[2] ?? '0'}.${match[3] ?? '0'}`)
+}
+
+/**
+ * `validVersion(version)` when it is strict semver, otherwise the coerced
+ * form; null when neither applies.
+ */
+export function normalizeVersion(version: string): string | null {
+  return validVersion(version) ?? coerceVersion(version)
+}
+
+function compareIdentifiers(a: string | number, b: string | number): number {
+  const aNumeric = typeof a === 'number'
+  const bNumeric = typeof b === 'number'
+  if (aNumeric && bNumeric) return a === b ? 0 : a < b ? -1 : 1
+  // Numeric identifiers always have lower precedence than alphanumeric ones.
+  if (aNumeric) return -1
+  if (bNumeric) return 1
+  return a === b ? 0 : a < b ? -1 : 1
+}
+
+function comparePrerelease(
+  a: Array<string | number>,
+  b: Array<string | number>,
+): number {
+  // A version without a prerelease has higher precedence than one with.
+  if (a.length === 0 && b.length === 0) return 0
+  if (a.length === 0) return 1
+  if (b.length === 0) return -1
+
+  const length = Math.max(a.length, b.length)
+  for (let index = 0; index < length; index++) {
+    const left = a[index]
+    const right = b[index]
+    // A longer identifier list wins once every shared identifier matches.
+    if (left === undefined) return -1
+    if (right === undefined) return 1
+    const result = compareIdentifiers(left, right)
+    if (result !== 0) return result
+  }
+  return 0
+}
+
+/**
+ * Equivalent to `semver.compare(a, b)` for two strict semver strings: -1, 0,
+ * or 1 by semver precedence. Throws on input that is not strict semver, as
+ * `semver.compare` does.
+ */
+export function compareVersions(a: string, b: string): number {
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+  if (!left) throw new TypeError(`Invalid Version: ${a}`)
+  if (!right) throw new TypeError(`Invalid Version: ${b}`)
+
+  return (
+    compareNumbers(left.major, right.major) ||
+    compareNumbers(left.minor, right.minor) ||
+    compareNumbers(left.patch, right.patch) ||
+    comparePrerelease(left.prerelease, right.prerelease)
+  )
+}
+
+function compareNumbers(a: number, b: number): number {
+  return a === b ? 0 : a < b ? -1 : 1
+}

--- a/packages/intent/tests/version.test.ts
+++ b/packages/intent/tests/version.test.ts
@@ -1,0 +1,106 @@
+import semver from 'semver'
+import { describe, expect, it } from 'vitest'
+import {
+  coerceVersion,
+  compareVersions,
+  normalizeVersion,
+  validVersion,
+} from '../src/shared/version.js'
+
+// The scanner's helpers must agree with `semver` on every input it might see,
+// so each case is checked against the reference implementation directly.
+const VERSIONS = [
+  '0.0.0',
+  '1.0.0',
+  '1.0.1',
+  '1.1.0',
+  '2.0.0',
+  '10.0.0',
+  '1.10.0',
+  '1.2.10',
+  'v1.2.3',
+  '=1.2.3',
+  ' 1.2.3 ',
+  '1.2.3+build.7',
+  '1.2.3-alpha',
+  '1.2.3-alpha.1',
+  '1.2.3-alpha.2',
+  '1.2.3-alpha.10',
+  '1.2.3-alpha.beta',
+  '1.2.3-beta',
+  '1.2.3-beta.2',
+  '1.2.3-beta.11',
+  '1.2.3-rc.1',
+  '1.2.3-rc.1+build',
+  '1.2.3-0',
+  '1.2.3-1',
+  '1.2.3-a',
+  '1.2.3--',
+  '1.2.3-0a',
+  '1.2.3-01',
+  '01.2.3',
+  '1.02.3',
+  '1.2',
+  '1',
+  '1.2.3.4',
+  'latest',
+  'workspace:*',
+  'v2',
+  '3.x',
+  'some 4.5 text',
+  'nightly-20240101',
+  '9007199254740993.0.0',
+  '',
+]
+
+describe('validVersion', () => {
+  it.each(VERSIONS)('matches semver.valid for %j', (version) => {
+    expect(validVersion(version)).toBe(semver.valid(version))
+  })
+})
+
+describe('coerceVersion', () => {
+  it.each(VERSIONS)('matches semver.coerce for %j', (version) => {
+    expect(coerceVersion(version)).toBe(semver.coerce(version)?.version ?? null)
+  })
+})
+
+describe('normalizeVersion', () => {
+  it.each(VERSIONS)('matches valid-then-coerce for %j', (version) => {
+    expect(normalizeVersion(version)).toBe(
+      semver.valid(version) ?? semver.coerce(version)?.version ?? null,
+    )
+  })
+})
+
+describe('compareVersions', () => {
+  const valid = VERSIONS.filter((version) => semver.valid(version) !== null)
+
+  it('agrees with semver.compare on every valid pair', () => {
+    for (const a of valid) {
+      for (const b of valid) {
+        expect(compareVersions(a, b), `${a} vs ${b}`).toBe(semver.compare(a, b))
+      }
+    }
+  })
+
+  it('orders the semver.org precedence example', () => {
+    const ordered = [
+      '1.0.0-alpha',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha.beta',
+      '1.0.0-beta',
+      '1.0.0-beta.2',
+      '1.0.0-beta.11',
+      '1.0.0-rc.1',
+      '1.0.0',
+    ]
+    const shuffled = [...ordered].reverse()
+    expect(shuffled.sort(compareVersions)).toEqual(ordered)
+  })
+
+  it('rejects input that is not strict semver', () => {
+    expect(() => compareVersions('1.2', '1.2.3')).toThrow(/Invalid Version/)
+    expect(() => compareVersions('1.2.3', 'latest')).toThrow(/Invalid Version/)
+  })
+})


### PR DESCRIPTION
## Summary

Second of the perf stack, stacked on #276 (resolver). Merge #276 first; this PR's diff will then reduce to its own commit.

Per-dependency import cost measured warm on Windows: `semver` 28 ms (46 CommonJS files), `@clack/prompts` 23 ms. Neither is needed on the `intent list` / `intent load` path, which is what the agent hooks run on every prompt.

- **Scanner no longer imports `semver`.** It only compared versions when two installs of the same package were found, using `valid`, `coerce`, and `compare`. A small `shared/version.ts` implements those three with identical semantics. `tests/version.test.ts` checks every helper against the real `semver` package over a table of edge cases (leading zeros, `v` prefix, build metadata, prerelease precedence, overflow) and all pairwise `compare` results. Staleness (`intent stale`) still uses `semver`; that chunk is not loaded by `list`/`load`.
- **`intent install` loads `@clack/prompts` on demand.** The static import pulled clack into the install chunk even for non-interactive runs (CI, `--map`, `--dry-run` with a configured policy). The one prompting call site now uses a dynamic import, which also splits `permission-prompts` into its own chunk.

A `createRequire`-based lazy `require('semver')` was considered and rejected: rolldown does not bundle through it, which would block the follow-up PR that bundles dependencies.

## Measurements (import + run of `main(['list'])`, warm)

| Scenario | #276 | this PR |
|---|---|---|
| empty project | ~100 ms | ~75 ms |
| `example/start-basic` | ~230 ms | ~215 ms |

`dist` chunk graph after build: `semver` is imported only by the staleness chunk; `@clack/prompts` only by the three prompt chunks.
