### PR TITLE
perf: bundle runtime dependencies into dist

### DIFF
--- a/.changeset/bundle-dependencies.md
+++ b/.changeset/bundle-dependencies.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Ship `@tanstack/intent` with zero runtime dependencies. The libraries it uses (`yaml`, `semver`, `jsonc-parser`, `cac`, `std-env`, `@clack/prompts`) are now bundled and tree-shaken into `dist`, which cuts the install footprint from roughly 2.4 MB across 10 packages to under 1 MB in one, and makes every command start faster because Node loads a few chunks instead of ~150 files from `node_modules`.

--- a/packages/intent/package.json
+++ b/packages/intent/package.json
@@ -28,22 +28,20 @@
     "dist",
     "meta"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@clack/prompts": "1.7.0",
+    "@types/semver": "^7.7.1",
     "cac": "^7.0.0",
     "jsonc-parser": "^3.3.1",
     "semver": "^7.8.4",
     "std-env": "^4.1.0",
-    "yaml": "2.9.0"
-  },
-  "devDependencies": {
-    "@types/semver": "^7.7.1",
     "tsdown": "^0.22.2",
-    "verdaccio": "^6.7.2"
+    "verdaccio": "^6.7.2",
+    "yaml": "2.9.0"
   },
   "scripts": {
     "prepack": "npm run build",
-    "build": "tsdown src/index.ts src/cli.ts src/core.ts --format esm --dts",
+    "build": "tsdown",
     "test:smoke": "pnpm run build && node dist/cli.mjs --help > /dev/null && node dist/cli.mjs load --help > /dev/null",
     "test:lib": "vitest run --exclude 'tests/integration/**'",
     "test:integration": "vitest run tests/integration/",

--- a/packages/intent/tsdown.config.ts
+++ b/packages/intent/tsdown.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli.ts', 'src/core.ts'],
+  format: 'esm',
+  platform: 'node',
+  dts: true,
+  // The libraries this package uses at runtime are declared as
+  // devDependencies so tsdown bundles them into dist. The published package
+  // then installs with zero dependencies, and the CLI starts faster because
+  // Node loads a few tree-shaken chunks instead of ~150 files spread across
+  // node_modules (yaml alone was 72 CommonJS modules and ~45ms).
+  alias: {
+    // jsonc-parser's `main` is a UMD build that rolldown cannot bundle (it
+    // requires './impl/*' at runtime); point at its ESM build instead.
+    'jsonc-parser': fileURLToPath(
+      new URL('./node_modules/jsonc-parser/lib/esm/main.js', import.meta.url),
+    ),
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,10 +73,13 @@ importers:
         version: 4.1.11(@types/node@25.9.5)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/intent:
-    dependencies:
+    devDependencies:
       '@clack/prompts':
         specifier: 1.7.0
         version: 1.7.0
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.8.0
       cac:
         specifier: ^7.0.0
         version: 7.0.0
@@ -89,19 +92,15 @@ importers:
       std-env:
         specifier: ^4.1.0
         version: 4.2.0
-      yaml:
-        specifier: 2.9.0
-        version: 2.9.0
-    devDependencies:
-      '@types/semver':
-        specifier: ^7.7.1
-        version: 7.8.0
       tsdown:
         specifier: ^0.22.2
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@6.0.3)
       verdaccio:
         specifier: ^6.7.2
         version: 6.10.1(supports-color@7.2.0)(typanion@3.14.0)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
 packages:
 


### PR DESCRIPTION
## Summary

Third of the perf stack, stacked on #278 (which is stacked on #276). Merge those first; this PR's diff then reduces to its own commit.

The published package currently pulls in 6 runtime dependencies (10 packages with transitives, ~2.4 MB installed), and on every command Node resolves and loads ~150 files out of `node_modules` (`yaml` alone is 72 CommonJS modules and ~45 ms warm). The compiled `dist` itself is 265 kB.

This PR moves `yaml`, `semver`, `jsonc-parser`, `cac`, `std-env`, and `@clack/prompts` to `devDependencies` and adds a `tsdown.config.ts` so tsdown bundles and tree-shakes them into `dist`. The published package has **zero runtime dependencies**; `dist` only imports `node:*` builtins.

One gotcha handled in the config: `jsonc-parser`'s `main` is a UMD build that rolldown cannot bundle (it `require`s `./impl/*` at runtime and fails with `Cannot find module './impl/format'`), so the config aliases it to the package's ESM entry.

## Measurements (Windows, warm)

| | before (#278) | this PR |
|---|---|---|
| `intent list`, empty project (import + run) | ~75 ms | ~35 ms |
| `intent list`, `example/start-basic` | ~215 ms | ~170 ms |
| `intent list`, this repo root (pnpm monorepo) | ~530 ms | ~490 ms |
| `npm pack` unpacked size | 382 kB + 2.4 MB of deps | 928 kB, no deps |

Across the whole stack, `intent list` on an empty project goes from ~100 ms to ~35 ms on top of Node's own ~85 ms startup, and the pnpm monorepo case from ~770 ms to ~490 ms.

## Trade-off

Security fixes in the bundled libraries now require an `@tanstack/intent` release rather than a consumer `npm update`. Renovate still bumps them as devDependencies, so the release cadence is the only change.
