### PR TITLE
perf: cut filesystem calls in the dependency walk

### DIFF
--- a/.changeset/fewer-walk-syscalls.md
+++ b/.changeset/fewer-walk-syscalls.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Cut the filesystem work in dependency discovery. Each dependency edge now costs one `readlink` instead of a stat through the symlink plus an `lstat` and a `realpath`; symlink targets, candidate paths, and `node_modules` directories are memoized per scan; and directories the walk has already resolved skip their identity `lstat`. Workspace pattern sorting no longer initializes the ICU collator on every run. `intent list` in a pnpm monorepo runs about 35% faster and in an npm project about 25% faster, with identical results.

--- a/packages/intent/src/discovery/fs-cache.ts
+++ b/packages/intent/src/discovery/fs-cache.ts
@@ -21,6 +21,8 @@ export type IntentFsCache = {
   readPackageJsonResult: (dir: string) => PackageJsonReadResult
   findSkillFiles: (dir: string) => Array<string>
   getFsIdentity: (path: string) => string
+  /** Record a directory known not to be a symlink, skipping its `lstat`. */
+  primeFsIdentity: (realPath: string) => void
   getStats: () => IntentFsCacheStats
   /**
    * Swap the filesystem used for all reads. Under Yarn PnP the scanner installs
@@ -95,6 +97,7 @@ export function createIntentFsCache(): IntentFsCache {
     readPackageJsonResult,
     findSkillFiles,
     getFsIdentity,
+    primeFsIdentity: getFsIdentity.prime,
     getStats: () => ({ ...stats }),
     useFs: (fs: ReadFs) => {
       activeFs = fs

--- a/packages/intent/src/discovery/scanner.ts
+++ b/packages/intent/src/discovery/scanner.ts
@@ -756,6 +756,7 @@ export function scanForIntents(
   } = createDependencyWalker({
     fsCache,
     getFsIdentity: fsCache.getFsIdentity,
+    primeFsIdentity: fsCache.primeFsIdentity,
     packages,
     projectRoot,
     readPkgJson,

--- a/packages/intent/src/discovery/walk.ts
+++ b/packages/intent/src/discovery/walk.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import {
+  createDepDirCache,
   getDeps,
   listNestedNodeModulesPackageDirs,
   resolveDepDir,
@@ -15,6 +16,8 @@ export interface CreateDependencyWalkerOptions {
   projectRoot: string
   readPkgJson: (dirPath: string) => PackageJson | null
   getFsIdentity: (path: string) => string
+  /** Marks a directory `resolveDepDir` returned as its own identity. */
+  primeFsIdentity?: (realPath: string) => void
   scanNodeModulesDir: (nodeModulesDir: string) => void
   tryRegister: (dirPath: string, fallbackName: string) => boolean
   packages: Array<IntentPackage>
@@ -24,6 +27,7 @@ export interface CreateDependencyWalkerOptions {
 export function createDependencyWalker(opts: CreateDependencyWalkerOptions) {
   const walkVisited = new Set<string>()
   const depDirCache = new Map<string, Map<string, string | null>>()
+  const depDirResolution = createDepDirCache()
 
   function resolveDepDirCached(
     depName: string,
@@ -36,11 +40,15 @@ export function createDependencyWalker(opts: CreateDependencyWalkerOptions) {
       depDirCache.set(fromKey, byDepName)
     }
 
-    if (!byDepName.has(depName)) {
-      byDepName.set(depName, resolveDepDir(depName, fromDir))
+    let depDir = byDepName.get(depName)
+    if (depDir === undefined) {
+      depDir = resolveDepDir(depName, fromDir, depDirResolution)
+      byDepName.set(depName, depDir)
+      // The result is already a real directory, so its identity is itself.
+      if (depDir) opts.primeFsIdentity?.(depDir)
     }
 
-    return byDepName.get(depName) ?? null
+    return depDir
   }
 
   function walkDepsOf(

--- a/packages/intent/src/setup/workspace-patterns.ts
+++ b/packages/intent/src/setup/workspace-patterns.ts
@@ -11,10 +11,19 @@ function normalizeWorkspacePattern(pattern: string): string {
   return pattern.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '')
 }
 
+/**
+ * Plain code-unit order. `localeCompare` would initialize the ICU collator
+ * (~7ms on first use, on every CLI run) and its order depends on the process
+ * locale; code-unit order is free and identical on every machine.
+ */
+function compareCodeUnits(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
 function normalizeWorkspacePatterns(patterns: Array<string>): Array<string> {
   return [
     ...new Set(patterns.map(normalizeWorkspacePattern).filter(Boolean)),
-  ].sort((a, b) => a.localeCompare(b))
+  ].sort(compareCodeUnits)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -275,7 +284,7 @@ export function resolveWorkspacePackages(
 
   return [...includedDirs]
     .filter((dir) => !excludedDirs.has(dir))
-    .sort((a, b) => a.localeCompare(b))
+    .sort(compareCodeUnits)
 }
 
 /** Recursively matches path segments: `*` matches one level, `**` matches zero or more levels. */

--- a/packages/intent/src/shared/utils.ts
+++ b/packages/intent/src/shared/utils.ts
@@ -430,9 +430,10 @@ function resolveCandidateDir(
     return existsSync(join(candidate, 'package.json')) ? candidate : null
   }
 
-  // Windows can report junction targets with the extended-length prefix.
-  if (target.startsWith('\\\\?\\')) target = target.slice(4)
-  const resolvedTarget = resolve(dirname(candidate), target)
+  const resolvedTarget = resolve(
+    dirname(candidate),
+    normalizeReadlinkTarget(target),
+  )
   let real = cache.targets.get(resolvedTarget)
   if (real === undefined) {
     real = existsSync(join(resolvedTarget, 'package.json'))
@@ -441,6 +442,20 @@ function resolveCandidateDir(
     cache.targets.set(resolvedTarget, real)
   }
   return real
+}
+
+/**
+ * Strip the Windows extended-length prefix that `readlink` can report for
+ * junction targets. `\\?\C:\dir` becomes `C:\dir`; `\\?\UNC\server\share`
+ * becomes `\\server\share` so the UNC root stays absolute. Other targets,
+ * including relative POSIX links, are returned unchanged.
+ */
+export function normalizeReadlinkTarget(target: string): string {
+  if (target.startsWith('\\\\?\\UNC\\')) {
+    return `\\\\${target.slice(8)}`
+  }
+  if (target.startsWith('\\\\?\\')) return target.slice(4)
+  return target
 }
 
 /**

--- a/packages/intent/src/shared/utils.ts
+++ b/packages/intent/src/shared/utils.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   readSync,
   readdirSync,
+  readlinkSync,
   realpathSync,
 } from 'node:fs'
 import { basename, dirname, join, resolve, sep } from 'node:path'
@@ -57,12 +58,22 @@ export function toPosixPath(p: string): string {
   return p.split(sep).join('/')
 }
 
+export interface FsIdentityResolver {
+  (path: string): string
+  /**
+   * Record that `realPath` is already an identity (not a symlink), so a later
+   * lookup returns it without an `lstat`. Callers use this for directories
+   * they have just resolved through `resolveDepDir`.
+   */
+  prime: (realPath: string) => void
+}
+
 export function createFsIdentityCache(
   getFs: () => ReadFs = () => nodeReadFs,
-): (path: string) => string {
+): FsIdentityResolver {
   const cache = new Map<string, string>()
 
-  return (path: string): string => {
+  const getIdentity = ((path: string): string => {
     const resolved = resolve(path)
     const cached = cache.get(resolved)
     if (cached) return cached
@@ -79,7 +90,14 @@ export function createFsIdentityCache(
 
     cache.set(resolved, identity)
     return identity
+  }) as FsIdentityResolver
+
+  getIdentity.prime = (realPath: string): void => {
+    const resolved = resolve(realPath)
+    if (!cache.has(resolved)) cache.set(resolved, resolved)
   }
+
+  return getIdentity
 }
 
 /**
@@ -207,7 +225,7 @@ export function listNodeModulesPackageDirs(
 
 export function listNestedNodeModulesPackageDirs(
   nodeModulesDir: string,
-  getFsIdentity = createFsIdentityCache(),
+  getFsIdentity: (path: string) => string = createFsIdentityCache(),
 ): Array<string> {
   const packageDirs: Array<string> = []
   const visitedNodeModulesDirs = new Set<string>()
@@ -327,6 +345,7 @@ export function detectGlobalNodeModules(packageManager: string): {
 export function resolveDepDir(
   depName: string,
   parentDir: string,
+  cache: DepDirCache = createDepDirCache(),
 ): string | null {
   let dir = parentDir
   let prev: string | undefined
@@ -334,9 +353,15 @@ export function resolveDepDir(
     // Node skips ancestors that are themselves node_modules directories
     // (`.../node_modules/node_modules/<dep>` is never a valid location).
     if (basename(dir) !== 'node_modules') {
-      const candidate = join(dir, 'node_modules', depName)
-      if (existsSync(join(candidate, 'package.json'))) {
-        return resolveRealDir(candidate)
+      const nodeModulesDir = join(dir, 'node_modules')
+      if (hasNodeModulesDir(nodeModulesDir, cache)) {
+        const candidate = join(nodeModulesDir, depName)
+        let resolved = cache.candidates.get(candidate)
+        if (resolved === undefined) {
+          resolved = resolveCandidateDir(candidate, cache)
+          cache.candidates.set(candidate, resolved)
+        }
+        if (resolved) return resolved
       }
     }
     prev = dir
@@ -344,6 +369,78 @@ export function resolveDepDir(
   }
 
   return null
+}
+
+/**
+ * Memo for `resolveDepDir` across one scan. A dependency graph revisits the
+ * same `node_modules` directories, candidate paths, and symlink targets many
+ * times (every package that depends on `semver` resolves it again), so the
+ * cache turns those repeats into map hits. It is never refreshed, so create
+ * one per scan rather than sharing it across runs.
+ */
+export interface DepDirCache {
+  /** `existsSync` result per `node_modules` directory. */
+  nodeModulesDirs: Map<string, boolean>
+  /** Resolution result per `node_modules/<dep>` candidate path. */
+  candidates: Map<string, string | null>
+  /** Real directory per resolved symlink target, shared by every link to it. */
+  targets: Map<string, string | null>
+}
+
+export function createDepDirCache(): DepDirCache {
+  return {
+    nodeModulesDirs: new Map(),
+    candidates: new Map(),
+    targets: new Map(),
+  }
+}
+
+function hasNodeModulesDir(dir: string, cache: DepDirCache): boolean {
+  let exists = cache.nodeModulesDirs.get(dir)
+  if (exists === undefined) {
+    exists = existsSync(dir)
+    cache.nodeModulesDirs.set(dir, exists)
+  }
+  return exists
+}
+
+/**
+ * Resolve one `node_modules/<dep>` candidate to its real directory, or null
+ * when no package is installed there.
+ *
+ * `readlink` is the first probe because it is the cheapest call that also
+ * tells symlinks apart: a stat that traverses a pnpm virtual-store link costs
+ * several times more than reading the link. Real directories (npm and Yarn
+ * hoisting) make it fail with EINVAL and are then checked directly; a missing
+ * entry fails with ENOENT.
+ */
+function resolveCandidateDir(
+  candidate: string,
+  cache: DepDirCache,
+): string | null {
+  let target: string | null
+  try {
+    target = readlinkSync(candidate)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    target = null
+  }
+
+  if (target === null) {
+    return existsSync(join(candidate, 'package.json')) ? candidate : null
+  }
+
+  // Windows can report junction targets with the extended-length prefix.
+  if (target.startsWith('\\\\?\\')) target = target.slice(4)
+  const resolvedTarget = resolve(dirname(candidate), target)
+  let real = cache.targets.get(resolvedTarget)
+  if (real === undefined) {
+    real = existsSync(join(resolvedTarget, 'package.json'))
+      ? resolveRealDir(resolvedTarget)
+      : null
+    cache.targets.set(resolvedTarget, real)
+  }
+  return real
 }
 
 /**

--- a/packages/intent/tests/resolve-dep-dir.test.ts
+++ b/packages/intent/tests/resolve-dep-dir.test.ts
@@ -9,7 +9,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { resolveDepDir } from '../src/shared/utils.js'
+import { createDepDirCache, resolveDepDir } from '../src/shared/utils.js'
 
 let root: string
 
@@ -71,5 +71,46 @@ describe('resolveDepDir', () => {
 
     expect(resolveDepDir('dep', parent)).toBeNull()
     expect(resolveDepDir('missing', parent)).toBeNull()
+  })
+
+  it('collapses a chain of symlinks to the final real directory', () => {
+    const real = createPackage(root, 'store', 'dep')
+    mkdirSync(join(root, 'hop'), { recursive: true })
+    symlinkSync(real, join(root, 'hop', 'dep'), 'junction')
+    mkdirSync(join(root, 'node_modules'), { recursive: true })
+    symlinkSync(
+      join(root, 'hop', 'dep'),
+      join(root, 'node_modules', 'dep'),
+      'junction',
+    )
+    const parent = createPackage(root, 'node_modules', 'parent')
+
+    expect(resolveDepDir('dep', parent)).toBe(real)
+  })
+
+  it('treats a dangling symlink as not installed', () => {
+    mkdirSync(join(root, 'node_modules'), { recursive: true })
+    symlinkSync(
+      join(root, 'missing'),
+      join(root, 'node_modules', 'dep'),
+      'junction',
+    )
+    const parent = createPackage(root, 'node_modules', 'parent')
+
+    expect(resolveDepDir('dep', parent)).toBeNull()
+  })
+
+  it('reuses a shared cache across parents and keeps answering correctly', () => {
+    const hoisted = createPackage(root, 'node_modules', 'dep')
+    const parentA = createPackage(root, 'node_modules', 'a')
+    const parentB = createPackage(root, 'node_modules', 'b')
+    const nested = createPackage(parentB, 'node_modules', 'dep')
+    const cache = createDepDirCache()
+
+    expect(resolveDepDir('dep', parentA, cache)).toBe(hoisted)
+    expect(resolveDepDir('dep', parentB, cache)).toBe(nested)
+    expect(resolveDepDir('dep', parentA, cache)).toBe(hoisted)
+    expect(resolveDepDir('other', parentA, cache)).toBeNull()
+    expect(cache.candidates.size).toBeGreaterThan(0)
   })
 })

--- a/packages/intent/tests/resolve-dep-dir.test.ts
+++ b/packages/intent/tests/resolve-dep-dir.test.ts
@@ -9,7 +9,11 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { createDepDirCache, resolveDepDir } from '../src/shared/utils.js'
+import {
+  createDepDirCache,
+  normalizeReadlinkTarget,
+  resolveDepDir,
+} from '../src/shared/utils.js'
 
 let root: string
 
@@ -112,5 +116,28 @@ describe('resolveDepDir', () => {
     expect(resolveDepDir('dep', parentA, cache)).toBe(hoisted)
     expect(resolveDepDir('other', parentA, cache)).toBeNull()
     expect(cache.candidates.size).toBeGreaterThan(0)
+  })
+})
+
+describe('normalizeReadlinkTarget', () => {
+  it('strips the extended-length prefix from drive paths', () => {
+    expect(normalizeReadlinkTarget('\\\\?\\C:\\store\\dep')).toBe(
+      'C:\\store\\dep',
+    )
+  })
+
+  it('keeps UNC targets absolute', () => {
+    expect(normalizeReadlinkTarget('\\\\?\\UNC\\server\\share\\dep')).toBe(
+      '\\\\server\\share\\dep',
+    )
+  })
+
+  it('leaves other targets alone', () => {
+    expect(normalizeReadlinkTarget('../../dep@1.0.0/node_modules/dep')).toBe(
+      '../../dep@1.0.0/node_modules/dep',
+    )
+    expect(normalizeReadlinkTarget('\\\\server\\share\\dep')).toBe(
+      '\\\\server\\share\\dep',
+    )
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #276, #278, and #279. After the resolver rewrite, a CPU profile of `intent list` at this repo's root was still dominated by raw filesystem calls: 2482 `existsSync`, 1244 `lstat`, and 779 `realpath` for 420 packages. Per-call costs on Windows explain why: a stat *through* a pnpm virtual-store symlink is ~150 µs, `lstat` ~70 µs, native `realpath` ~120 µs, while `readlink` is ~37 µs.

This PR changes how each dependency edge is resolved:

- **`readlink` first.** A symlink yields its target directly; a real directory (npm/Yarn hoisting) fails with `EINVAL` and is checked once; a missing entry fails with `ENOENT`. Windows junction targets with the `\?\` prefix are handled.
- **Per-scan memo** (`createDepDirCache`) for `node_modules` directory existence, candidate paths, and symlink targets. Fifty packages depending on `semver` used to resolve and `realpath` its store link fifty times; now the target is resolved once. `resolveDepDir` keeps its two-argument public signature; the cache is an optional third parameter.
- **Identity priming.** Directories the walk has just resolved are real paths, so the walker records them in the identity cache instead of `lstat`-ing them again.
- **Code-unit sort** for workspace patterns and package directories. `localeCompare` initialized the ICU collator (~7 ms) on every CLI run, and its order depends on the process locale; code-unit order is free and identical everywhere.

## Measurements (Windows, warm, import + run of `main(['list'])`)

| Scenario | main (#279) | this PR |
|---|---|---|
| this repo root (pnpm monorepo, 420 pkgs) | ~500 ms | ~320 ms |
| npm example (97 top-level pkgs, 24 skills) | ~180 ms | ~135 ms |
| empty project | ~35 ms | ~32 ms |

Syscalls at the repo root: `existsSync` 2482 → 1382, `lstat` 1244 → 465, `realpath` 779 → 0. `list --json` output is byte-identical before and after on the npm example, and the resolver test file gains symlink-chain, dangling-link, and shared-cache cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved dependency discovery speed, with reported gains of approximately 35% in pnpm monorepos and 25% in npm projects.
  * Preserved existing discovery results while reducing filesystem work and repeated path resolution.
  * Made workspace package ordering deterministic across locales.

* **Bug Fixes**
  * Improved handling of chained and dangling symlinks during dependency discovery.
  * Preserved correct nested and hoisted dependency resolution when reusing cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->