### PR TITLE
fix: pick an escape placeholder that cannot collide with the destination

### DIFF
--- a/.changeset/markdown-placeholder-collision.md
+++ b/.changeset/markdown-placeholder-collision.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/intent': patch
+---
+
+Keep Markdown link destinations that contain a private-use character (U+E000) intact when `intent load` and `intent meta` rewrite relative paths; the escape placeholder is now chosen so it never collides with the destination's own characters.

--- a/packages/intent/src/core/markdown.ts
+++ b/packages/intent/src/core/markdown.ts
@@ -1,8 +1,17 @@
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { toPosixPath } from '../shared/utils.js'
 
-/** Private-use character that no path function treats as a separator. */
-const BACKSLASH_PLACEHOLDER = '\uE000'
+/**
+ * A character that does not occur in `text`, taken from the Unicode private
+ * use area so no path function treats it as a separator. Scanning for a free
+ * code point keeps a destination that already contains such a character (a
+ * literal U+E000, say) from being rewritten as a backslash.
+ */
+function pickPlaceholder(text: string): string {
+  let codePoint = 0xe000
+  while (text.includes(String.fromCharCode(codePoint))) codePoint++
+  return String.fromCharCode(codePoint)
+}
 
 function resolveFromCwd(path: string): string {
   return resolve(process.cwd(), path)
@@ -177,9 +186,10 @@ function rewriteMarkdownDestination({
   // A backslash in a Markdown destination is an escape (`\)`), never a path
   // separator. Hide it from the path functions, which on Windows would
   // otherwise normalize it into `/`, and restore it in the rewritten output.
+  const placeholder = pickPlaceholder(pathPart)
   const resolvedDestinationPath = resolve(
     context.skillDir,
-    pathPart.replaceAll('\\', BACKSLASH_PLACEHOLDER),
+    pathPart.replaceAll('\\', placeholder),
   )
   const relativeToPackageRoot = relative(
     context.resolvedPackageRoot,
@@ -200,7 +210,7 @@ function rewriteMarkdownDestination({
       ? relativeToCwd
       : resolvedDestinationPath
 
-  const rewritten = `${toPosixPath(rewrittenPath).replaceAll(BACKSLASH_PLACEHOLDER, '\\')}${suffix}`
+  const rewritten = `${toPosixPath(rewrittenPath).replaceAll(placeholder, '\\')}${suffix}`
   context.rewrittenDestinations.set(destination, rewritten)
   return rewritten
 }

--- a/packages/intent/tests/markdown.test.ts
+++ b/packages/intent/tests/markdown.test.ts
@@ -28,6 +28,12 @@ describe('rewriteLoadedSkillMarkdownDestinations', () => {
     )
   })
 
+  it('keeps private-use characters in destinations intact alongside escapes', () => {
+    expect(rewrite('[Odd](docs/a\uE000b\\).md)')).toBe(
+      '[Odd](node_modules/pkg/skills/core/docs/a\uE000b\\).md)',
+    )
+  })
+
   it('preserves malformed inline links', () => {
     expect(rewrite('[Broken](docs/api.md')).toBe('[Broken](docs/api.md')
   })


### PR DESCRIPTION
## Summary

Follow-up to CodeRabbit's finding on #275. The Markdown destination rewrite hid backslash escapes behind a fixed U+E000 while path functions ran, then restored every U+E000 as a backslash, so a destination that already contained U+E000 (`docs/a\uE000b.md`) was corrupted. The placeholder is now the first private-use code point that does not occur in the destination. Test added for a destination containing both U+E000 and an escaped paren.