### PR TITLE
ci: include tsdown.config.ts in the package tsconfig so typed lint can parse it

### DIFF
--- a/packages/intent/tsconfig.json
+++ b/packages/intent/tsconfig.json
@@ -4,5 +4,10 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src", "tests", "vitest.config.ts"]
+  "include": [
+    "src",
+    "tests",
+    "tsdown.config.ts",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/intent/tsconfig.json
+++ b/packages/intent/tsconfig.json
@@ -4,10 +4,5 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": [
-    "src",
-    "tests",
-    "tsdown.config.ts",
-    "vitest.config.ts"
-  ]
+  "include": ["src", "tests", "tsdown.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

`test:eslint` fails on `main` since #279: `tsdown.config.ts` is not in `packages/intent/tsconfig.json`'s `include`, and the typed `@typescript-eslint` parser errors on files outside the project (`vitest.config.ts` is listed there for the same reason). Every open PR inherits the failure. Add the config file to the include list; `tsc --noEmit` and `eslint .` are clean with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript project coverage to include an additional configuration file in compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->